### PR TITLE
Add gitignore with env exclusions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+node_modules/
+.env
+.env.*
+
+# Logs
+logs
+*.log
+npm-debug.log*
+
+# Build
+client/dist/
+server/node_modules/
+client/node_modules/
+
+# OS
+.DS_Store


### PR DESCRIPTION
## Summary
- add a root `.gitignore` that ignores node modules and environment files

## Testing
- `npm -v`
- `npm test --workspaces` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68877b509e4c832eb794d19e62bb770c