### PR TITLE
Fix MongoDB connection configuration

### DIFF
--- a/server/config/db.js
+++ b/server/config/db.js
@@ -1,14 +1,25 @@
 import mongoose from 'mongoose';
+import dotenv from 'dotenv';
 
-export const connectDB = async () => {
+dotenv.config();
+
+const connectDB = async () => {
   try {
-    const conn = await mongoose.connect(process.env.MONGODB_URI, {
+    const mongoUri = process.env.MONGO_URI || process.env.MONGODB_URI;
+    if (!mongoUri) {
+      throw new Error('MONGO_URI is not defined');
+    }
+
+    const conn = await mongoose.connect(mongoUri, {
       useNewUrlParser: true,
       useUnifiedTopology: true,
     });
     console.log(`MongoDB Connected: ${conn.connection.host}`);
   } catch (error) {
-    console.error('Error connecting to MongoDB:', error.message);
+    console.error('MongoDB connection failed:', error.message);
     process.exit(1);
   }
 };
+
+export { connectDB };
+export default connectDB;


### PR DESCRIPTION
## Summary
- load environment variables in `connectDB`
- add a fallback for `MONGO_URI` and improved error handling
- export `connectDB` both as a default and named export

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `node server.js` *(fails: cannot find module 'express' because deps weren't installed)*

------
https://chatgpt.com/codex/tasks/task_e_688793c8f04c832e80146735620dba94