### PR TITLE
Fix MongoDB env var typo and update mailer

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ Create a `.env` file inside the `server/` directory with the following
 variable:
 
 ```
-MONGO_URI=mongodb+srv://hassansufims7-8:hassansufims7-8@cluster0.h5vbmbs.mongodb.net/?retryWrites=true&w=majority&appName=Cluster0
+MONGODB_URI=mongodb+srv://hassansufims7-8:hassansufims7-8@cluster0.h5vbmbs.mongodb.net/?retryWrites=true&w=majority&appName=Cluster0
 ```
 
-When deploying to [Render](https://render.com), add the same `MONGO_URI`
+When deploying to [Render](https://render.com), add the same `MONGODB_URI`
 value in the **Environment** settings for your service.

--- a/server/.env
+++ b/server/.env
@@ -1,4 +1,4 @@
-MONGO_URI=mongodb+srv://hassansufims7-8:hassansufims7-8@cluster0.h5vbmbs.mongodb.net/?retryWrites=true&w=majority&appName=Cluster0
+MONGODB_URI=mongodb+srv://hassansufims7-8:hassansufims7-8@cluster0.h5vbmbs.mongodb.net/?retryWrites=true&w=majority&appName=Cluster0
 
 
 

--- a/server/config/db.js
+++ b/server/config/db.js
@@ -2,7 +2,7 @@ const mongoose = require('mongoose');
 
 const connectDB = async () => {
   try {
-    await mongoose.connect(process.env.MONGO_URI, {
+    await mongoose.connect(process.env.MONGODB_URI, {
       useNewUrlParser: true,
       useUnifiedTopology: true,
     });

--- a/server/routes/forgot.js
+++ b/server/routes/forgot.js
@@ -17,7 +17,7 @@ router.post("/forgot-password", async (req, res) => {
     resetTokens[email] = token;
 
     const resetLink = `https://your-frontend-domain/reset-password/${token}`;
-    const transporter = nodemailer.createTransporter({
+    const transporter = nodemailer.createTransport({
       service: "gmail",
       auth: {
         user: process.env.RESET_EMAIL,


### PR DESCRIPTION
## Summary
- update README to use `MONGODB_URI`
- align server's database config with new variable
- fix `createTransport` typo in reset password route
- update example .env file

## Testing
- `node -c server/config/db.js`
- `node -c server/routes/forgot.js`

------
https://chatgpt.com/codex/tasks/task_e_688b76f1afe4832ea8215d5799c13a9a