### PR TITLE
Fix signup fetch API URL

### DIFF
--- a/client/src/utils/api.js
+++ b/client/src/utils/api.js
@@ -1,7 +1,10 @@
-// Use relative URL by default so frontend and backend can run on the same host
-// without needing environment configuration. A custom base URL can still be
-// provided via VITE_API_BASE_URL when required.
-const BASE_URL = import.meta.env.VITE_API_BASE_URL || '';
+// Resolve API base URL automatically. In production the frontend and backend
+// are served from the same origin so we can use a relative URL. During
+// development the Vite dev server runs on a different port, so default to the
+// Express server running on localhost unless a custom `VITE_API_BASE_URL` is
+// provided.
+const BASE_URL =
+  import.meta.env.VITE_API_BASE_URL || (import.meta.env.DEV ? 'http://localhost:5000' : '');
 
 export const apiCall = async (endpoint, options = {}) => {
   const url = `${BASE_URL}${endpoint}`;

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -6,6 +6,9 @@ export default defineConfig({
   server: {
     host: true,
     allowedHosts: ["5173-ir9r7ynopmk7aad5w8lmt-631abee1.manusvm.computer"],
+    proxy: {
+      '/api': 'http://localhost:5000'
+    }
   },
   plugins: [
     react(),


### PR DESCRIPTION
## Summary
- default API URL to localhost while developing
- proxy `/api` to backend during local dev

## Testing
- `npm --prefix client run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b92d1f1a0832eacb4f88514fa17ed