### PR TITLE
Fix auth request errors

### DIFF
--- a/client/src/utils/api.js
+++ b/client/src/utils/api.js
@@ -28,9 +28,6 @@ export const apiCall = async (endpoint, options = {}) => {
   try {
     const response = await fetch(url, config);
     const data = await response.json();
-    if (!response.ok) {
-      throw new Error(data.message || `HTTP error! status: ${response.status}`);
-    }
     return {
       ok: response.ok,
       status: response.status,

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -7,6 +7,9 @@ const router = express.Router();
 
 router.post("/signup", async (req, res) => {
   const { email, password } = req.body;
+  if (!email || !password) {
+    return res.status(400).json({ msg: "Email and password are required" });
+  }
   console.log("Signup attempt for email:", email);
   try {
     const exists = await User.findOne({ email });
@@ -34,6 +37,9 @@ router.post("/signup", async (req, res) => {
 
 router.post("/login", async (req, res) => {
   const { email, password } = req.body;
+  if (!email || !password) {
+    return res.status(400).json({ msg: "Email and password are required" });
+  }
   try {
     const user = await User.findOne({ email });
     if (!user) return res.status(400).json({ msg: "Invalid credentials" });

--- a/server/routes/forgot.js
+++ b/server/routes/forgot.js
@@ -10,6 +10,9 @@ let resetTokens = {};
 // support both /forgot-password (documented) and /forgot (legacy)
 router.post(["/forgot-password", "/forgot"], async (req, res) => {
   const { email } = req.body;
+  if (!email) {
+    return res.status(400).json({ msg: "Email is required" });
+  }
   try {
     const user = await User.findOne({ email });
     if (!user) return res.status(400).json({ msg: "User not found" });
@@ -52,6 +55,9 @@ router.post(["/forgot-password", "/forgot"], async (req, res) => {
 router.post("/reset-password/:token", async (req, res) => {
   const { token } = req.params;
   const { email, newPassword } = req.body;
+  if (!email || !newPassword) {
+    return res.status(400).json({ msg: "Email and new password are required" });
+  }
 
   try {
     if (resetTokens[email] !== token) return res.status(400).json({ msg: "Invalid token" });


### PR DESCRIPTION
## Summary
- improve `apiCall` so it always returns server responses
- validate required fields in auth and forgot password routes

## Testing
- `npm install` *(fails: registry access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_688bc54dcdd0832ea8cadc4cf8efdb66