### PR TITLE
Fix forgot password reset link

### DIFF
--- a/server/.env
+++ b/server/.env
@@ -7,3 +7,5 @@ JWT_PUBLIC_KEY_BASE64=LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUlJQklqQU5CZ2txaGtpRz
 
 RESET_EMAIL=h2358034@gmail.com
 RESET_PASS=lkdvegnujwytvlgb
+
+FRONTEND_URL=https://moohaarapp.onrender.com

--- a/server/routes/forgot.js
+++ b/server/routes/forgot.js
@@ -20,8 +20,8 @@ router.post(["/forgot-password", "/forgot"], async (req, res) => {
     const token = crypto.randomBytes(32).toString("hex");
     resetTokens[email] = token;
 
-    // Build password reset link using optional CLIENT_URL env or default localhost
-    const baseUrl = process.env.CLIENT_URL || "http://localhost:5173";
+    // Build password reset link using optional FRONTEND_URL env or default localhost
+    const baseUrl = process.env.FRONTEND_URL || "http://localhost:5173";
     const resetLink = `${baseUrl}/reset-password/${token}`;
 
     // Ensure email credentials are defined


### PR DESCRIPTION
## Summary
- update forgot password route to use `FRONTEND_URL`
- add `FRONTEND_URL` to environment file

## Testing
- `node - <<'EOF'
process.env.FRONTEND_URL='https://moohaarapp.onrender.com';
const baseUrl = process.env.FRONTEND_URL || 'http://localhost:5173';
const token='testtoken';
console.log(`${baseUrl}/reset-password/${token}`);
EOF`
- `npm --prefix server start` *(fails: MongoDB connection error)*

------
https://chatgpt.com/codex/tasks/task_e_688c4b768338832eb24489cec483a92c