### PR TITLE
Add sidebar and profile features

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -3,6 +3,8 @@ import Home from './pages/Home';
 import Login from './pages/Login';
 import Signup from './pages/Signup';
 import Dashboard from './pages/Dashboard';
+import Profile from './pages/Profile';
+import Analytics from './pages/Analytics';
 import CreateStore from './pages/CreateStore';
 import ForgotPassword from './pages/ForgotPassword';
 import ResetPassword from './pages/ResetPassword';
@@ -15,6 +17,8 @@ export default function App() {
         <Route path="/login" element={<Login />} />
         <Route path="/signup" element={<Signup />} />
         <Route path="/dashboard" element={<Dashboard />} />
+        <Route path="/profile" element={<Profile />} />
+        <Route path="/analytics" element={<Analytics />} />
         <Route path="/create-store" element={<CreateStore />} />
         <Route path="/forgot-password" element={<ForgotPassword />} />
         <Route path="/reset-password/:token" element={<ResetPassword />} />

--- a/client/src/pages/Analytics.jsx
+++ b/client/src/pages/Analytics.jsx
@@ -1,0 +1,8 @@
+export default function Analytics() {
+  return (
+    <div className="p-4">
+      <h2 className="text-2xl font-semibold">Analytics</h2>
+      <p className="text-gray-600">Coming soon...</p>
+    </div>
+  );
+}

--- a/client/src/pages/CreateStore.jsx
+++ b/client/src/pages/CreateStore.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { apiCall } from '../utils/api';
 
@@ -15,6 +15,23 @@ export default function CreateStore() {
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
   const navigate = useNavigate();
+
+  useEffect(() => {
+    const token = localStorage.getItem('token');
+    if (!token) {
+      navigate('/login');
+      return;
+    }
+    const checkStore = async () => {
+      const result = await apiCall('/api/store/me', {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (result.ok) {
+        navigate('/dashboard');
+      }
+    };
+    checkStore();
+  }, [navigate]);
 
   const handleChange = (e) => {
     setFormData({

--- a/client/src/pages/Dashboard.jsx
+++ b/client/src/pages/Dashboard.jsx
@@ -1,8 +1,11 @@
 import { useState, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
+import { apiCall } from '../utils/api';
 
 export default function Dashboard() {
   const [user, setUser] = useState(null);
+  const [store, setStore] = useState(null);
+  const [menuOpen, setMenuOpen] = useState(false);
   const [loading, setLoading] = useState(true);
   const navigate = useNavigate();
 
@@ -16,7 +19,18 @@ export default function Dashboard() {
     }
 
     setUser(JSON.parse(userData));
-    setLoading(false);
+
+    const fetchStore = async () => {
+      const result = await apiCall('/api/store/me', {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (result.ok) {
+        setStore(result.data);
+      }
+      setLoading(false);
+    };
+
+    fetchStore();
   }, [navigate]);
 
   const handleLogout = () => {
@@ -29,7 +43,7 @@ export default function Dashboard() {
     return (
       <div className="min-h-screen bg-gray-50 flex items-center justify-center">
         <div className="text-center">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-indigo-600 mx-auto"></div>
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-indigo-600 mx-auto" />
           <p className="mt-4 text-gray-600">Loading...</p>
         </div>
       </div>
@@ -37,63 +51,139 @@ export default function Dashboard() {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50">
-      <nav className="bg-white shadow">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex justify-between h-16">
-            <div className="flex items-center">
-              <h1 className="text-xl font-semibold text-gray-900">Dashboard</h1>
-            </div>
-            <div className="flex items-center space-x-4">
-              <span className="text-gray-700">Welcome, {user?.email}</span>
-              <button
-                onClick={handleLogout}
-                className="bg-indigo-600 hover:bg-indigo-700 text-white px-4 py-2 rounded-md text-sm font-medium"
-              >
-                Logout
-              </button>
+    <div className="min-h-screen bg-gray-50 flex">
+      {/* Sidebar for desktop */}
+      <aside
+        className={`hidden md:flex flex-col w-56 bg-white border-r shadow-sm p-4 space-y-4 ${
+          menuOpen ? '' : ''
+        }`}
+      >
+        <Link to="/dashboard" className="hover:text-accent">
+          Dashboard
+        </Link>
+        {!store && (
+          <Link to="/create-store" className="hover:text-accent">
+            Create Store
+          </Link>
+        )}
+        <Link to="/profile" className="hover:text-accent">
+          Profile
+        </Link>
+        <Link to="/analytics" className="hover:text-accent">
+          Analytics
+        </Link>
+        <button onClick={handleLogout} className="text-left hover:text-accent">
+          Logout
+        </button>
+      </aside>
+
+      <div className="flex-1 flex flex-col">
+        <nav className="bg-white shadow relative">
+          <div className="flex items-center justify-between p-4">
+            <button
+              onClick={() => setMenuOpen(!menuOpen)}
+              className="md:hidden p-2"
+              aria-label="Menu"
+            >
+              <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                {menuOpen ? (
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M6 18L18 6M6 6l12 12" />
+                ) : (
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4 6h16M4 12h16M4 18h16" />
+                )}
+              </svg>
+            </button>
+            <div className="absolute left-1/2 -translate-x-1/2 text-center">
+              <span className="block font-bold text-xl text-primary">Moohaar</span>
+              <span className="block font-nastaliq tracking-wide text-gold text-sm">ویبسائٹ آج اور ابھی</span>
             </div>
           </div>
-        </div>
-      </nav>
+          {/* mobile dropdown */}
+          {menuOpen && (
+            <div className="md:hidden border-t">
+              <div className="flex flex-col p-4 space-y-2">
+                <Link to="/dashboard" onClick={() => setMenuOpen(false)} className="hover:text-accent">
+                  Dashboard
+                </Link>
+                {!store && (
+                  <Link to="/create-store" onClick={() => setMenuOpen(false)} className="hover:text-accent">
+                    Create Store
+                  </Link>
+                )}
+                <Link to="/profile" onClick={() => setMenuOpen(false)} className="hover:text-accent">
+                  Profile
+                </Link>
+                <Link to="/analytics" onClick={() => setMenuOpen(false)} className="hover:text-accent">
+                  Analytics
+                </Link>
+                <button onClick={handleLogout} className="text-left hover:text-accent">
+                  Logout
+                </button>
+              </div>
+            </div>
+          )}
+        </nav>
 
-      <main className="max-w-7xl mx-auto py-6 sm:px-6 lg:px-8">
+        <main className="max-w-7xl mx-auto py-6 px-4 flex-1">
         <div className="px-4 py-6 sm:px-0">
           <div className="border-4 border-dashed border-gray-200 rounded-lg p-8">
             <div className="text-center">
-              <h2 className="text-2xl font-bold text-gray-900 mb-4">
+              <h2 className="text-2xl font-bold text-gray-900 mb-2">
                 Welcome to your Dashboard!
               </h2>
+              <p className="text-gray-600">{user?.name ? `${user.name} - ${user.email}` : user?.email}</p>
               <p className="text-gray-600 mb-8">
                 You have successfully logged in. This is your protected dashboard area.
               </p>
               
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-                <div className="bg-white p-6 rounded-lg shadow">
-                  <h3 className="text-lg font-medium text-gray-900 mb-2">Create Store</h3>
-                  <p className="text-gray-600 mb-4">Set up your online store</p>
-                  <button
-                    onClick={() => navigate('/create-store')}
-                    className="bg-indigo-600 hover:bg-indigo-700 text-white px-4 py-2 rounded-md text-sm font-medium"
-                  >
-                    Get Started
-                  </button>
-                </div>
+                {!store && (
+                  <div className="bg-white p-6 rounded-lg shadow">
+                    <h3 className="text-lg font-medium text-gray-900 mb-2">Create Store</h3>
+                    <p className="text-gray-600 mb-4">Set up your online store</p>
+                    <button
+                      onClick={() => navigate('/create-store')}
+                      className="bg-indigo-600 hover:bg-indigo-700 text-white px-4 py-2 rounded-md text-sm font-medium"
+                    >
+                      Get Started
+                    </button>
+                  </div>
+                )}
+                {store && (
+                  <div className="bg-white p-6 rounded-lg shadow text-left">
+                    <h3 className="text-lg font-medium text-gray-900 mb-2">My Store</h3>
+                    <p className="text-gray-600 mb-1">{store.storeName}</p>
+                    <p className="text-gray-600 mb-1">WhatsApp: {store.storeWhatsapp}</p>
+                    <p className="text-gray-600 mb-4">{store.storeAddress}</p>
+                    <Link
+                      to="/profile"
+                      className="text-indigo-600 hover:underline text-sm"
+                    >
+                      Edit Store Info
+                    </Link>
+                  </div>
+                )}
 
                 <div className="bg-white p-6 rounded-lg shadow">
                   <h3 className="text-lg font-medium text-gray-900 mb-2">Profile</h3>
                   <p className="text-gray-600 mb-4">Manage your account settings</p>
-                  <button className="bg-gray-600 hover:bg-gray-700 text-white px-4 py-2 rounded-md text-sm font-medium">
+                  <Link
+                    to="/profile"
+                    className="bg-gray-600 hover:bg-gray-700 text-white px-4 py-2 rounded-md text-sm font-medium inline-block"
+                  >
                     View Profile
-                  </button>
+                  </Link>
                 </div>
 
                 <div className="bg-white p-6 rounded-lg shadow">
                   <h3 className="text-lg font-medium text-gray-900 mb-2">Analytics</h3>
                   <p className="text-gray-600 mb-4">View your store analytics</p>
-                  <button className="bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded-md text-sm font-medium">
+                  <Link
+                    to="/analytics"
+                    className="bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded-md text-sm font-medium inline-block"
+                  >
                     View Analytics
-                  </button>
+                  </Link>
                 </div>
               </div>
             </div>
@@ -101,6 +191,7 @@ export default function Dashboard() {
         </div>
       </main>
     </div>
+  </div>
   );
 }
 

--- a/client/src/pages/Profile.jsx
+++ b/client/src/pages/Profile.jsx
@@ -1,0 +1,131 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { apiCall } from '../utils/api';
+
+export default function Profile() {
+  const [store, setStore] = useState(null);
+  const [formData, setFormData] = useState({
+    storeName: '',
+    storeWhatsapp: '',
+    storeAddress: '',
+    businessCategory: '',
+  });
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const navigate = useNavigate();
+
+  const token = localStorage.getItem('token');
+  const userData = localStorage.getItem('user');
+  const user = userData ? JSON.parse(userData) : null;
+
+  useEffect(() => {
+    if (!token || !user) {
+      navigate('/login');
+      return;
+    }
+    const fetchStore = async () => {
+      const result = await apiCall('/api/store/me', {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (result.ok) {
+        setStore(result.data);
+        setFormData({
+          storeName: result.data.storeName || '',
+          storeWhatsapp: result.data.storeWhatsapp || '',
+          storeAddress: result.data.storeAddress || '',
+          businessCategory: result.data.businessCategory || '',
+        });
+      }
+      setLoading(false);
+    };
+    fetchStore();
+  }, [navigate, token, user]);
+
+  const handleChange = (e) => {
+    setFormData({ ...formData, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setSaving(true);
+    const result = await apiCall('/api/store/update', {
+      method: 'PUT',
+      headers: { Authorization: `Bearer ${token}` },
+      body: JSON.stringify(formData),
+    });
+    if (result.ok) {
+      setStore(result.data);
+      alert('Profile updated');
+    } else {
+      alert(result.data.msg || 'Update failed');
+    }
+    setSaving(false);
+  };
+
+  if (loading) {
+    return <div className="p-4">Loading...</div>;
+  }
+
+  return (
+    <div className="max-w-xl mx-auto p-4 space-y-6">
+      <h2 className="text-2xl font-semibold">Profile</h2>
+      <p className="text-gray-600">{user?.email}</p>
+
+      {store ? (
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label className="block text-sm font-medium">Store Name</label>
+            <input
+              type="text"
+              name="storeName"
+              value={formData.storeName}
+              onChange={handleChange}
+              className="mt-1 block w-full border rounded p-2"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium">WhatsApp</label>
+            <input
+              type="text"
+              name="storeWhatsapp"
+              value={formData.storeWhatsapp}
+              onChange={handleChange}
+              className="mt-1 block w-full border rounded p-2"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium">Address</label>
+            <input
+              type="text"
+              name="storeAddress"
+              value={formData.storeAddress}
+              onChange={handleChange}
+              className="mt-1 block w-full border rounded p-2"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium">Business Category</label>
+            <input
+              type="text"
+              name="businessCategory"
+              value={formData.businessCategory}
+              onChange={handleChange}
+              className="mt-1 block w-full border rounded p-2"
+            />
+          </div>
+          <div className="flex justify-end">
+            <button
+              type="submit"
+              disabled={saving}
+              className="bg-indigo-600 text-white px-4 py-2 rounded disabled:opacity-50"
+            >
+              {saving ? 'Saving...' : 'Save'}
+            </button>
+          </div>
+        </form>
+      ) : (
+        <div>No store found. Create one first.</div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- enhance dashboard layout with burger menu, sidebar, and store info
- add profile and analytics pages
- enforce single store per user on backend
- allow editing store profile
- redirect from create-store if store already exists

## Testing
- `npm run build` in `client`
- `node server.js` *(fails: Mongo connection error as expected)*

------
https://chatgpt.com/codex/tasks/task_e_688c8c91b6a4832e90438e7cdba9cad8