### PR TITLE
Add theme selection and ThemeStore page

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -8,6 +8,7 @@ import Analytics from './pages/Analytics';
 import CreateStore from './pages/CreateStore';
 import ForgotPassword from './pages/ForgotPassword';
 import ResetPassword from './pages/ResetPassword';
+import ThemeStore from './pages/ThemeStore';
 
 export default function App() {
   return (
@@ -20,6 +21,7 @@ export default function App() {
         <Route path="/profile" element={<Profile />} />
         <Route path="/analytics" element={<Analytics />} />
         <Route path="/create-store" element={<CreateStore />} />
+        <Route path="/themes" element={<ThemeStore />} />
         <Route path="/forgot-password" element={<ForgotPassword />} />
         <Route path="/reset-password/:token" element={<ResetPassword />} />
       </Routes>

--- a/client/src/pages/CreateStore.jsx
+++ b/client/src/pages/CreateStore.jsx
@@ -57,7 +57,7 @@ export default function CreateStore() {
 
       if (result.ok) {
         alert('Store created successfully!');
-        navigate('/dashboard');
+        navigate('/themes');
       } else {
         setError(result.data.msg || 'Store creation failed. Please try again.');
       }

--- a/client/src/pages/ThemeStore.jsx
+++ b/client/src/pages/ThemeStore.jsx
@@ -1,0 +1,120 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { apiCall } from '../utils/api';
+
+export default function ThemeStore() {
+  const [themes, setThemes] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const token = localStorage.getItem('token');
+    if (!token) {
+      navigate('/login');
+      return;
+    }
+
+    const init = async () => {
+      // Ensure user has a store
+      const storeRes = await apiCall('/api/store/me', {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (!storeRes.ok) {
+        navigate('/create-store');
+        return;
+      }
+
+      // Dummy themes list
+      const dummyThemes = [
+        {
+          id: 'classic-shop',
+          name: 'Classic Shop',
+          image: 'https://via.placeholder.com/300x200.png?text=Classic+Shop',
+          previewUrl: 'https://example.com/classic-shop',
+        },
+        {
+          id: 'fashion-cart',
+          name: 'Fashion Cart',
+          image: 'https://via.placeholder.com/300x200.png?text=Fashion+Cart',
+          previewUrl: 'https://example.com/fashion-cart',
+        },
+        {
+          id: 'grocery-mart',
+          name: 'GroceryMart',
+          image: 'https://via.placeholder.com/300x200.png?text=GroceryMart',
+          previewUrl: 'https://example.com/grocery-mart',
+        },
+        {
+          id: 'tech-bazaar',
+          name: 'Tech Bazaar',
+          image: 'https://via.placeholder.com/300x200.png?text=Tech+Bazaar',
+          previewUrl: 'https://example.com/tech-bazaar',
+        },
+      ];
+      setThemes(dummyThemes);
+      setLoading(false);
+    };
+
+    init();
+  }, [navigate]);
+
+  const handleSelect = async (themeId) => {
+    const token = localStorage.getItem('token');
+    const res = await apiCall('/api/store/theme', {
+      method: 'PUT',
+      headers: { Authorization: `Bearer ${token}` },
+      body: JSON.stringify({ theme: themeId }),
+    });
+    if (res.ok) {
+      navigate('/dashboard');
+    } else {
+      alert(res.data.msg || 'Failed to select theme');
+    }
+  };
+
+  const handlePreview = (url) => {
+    window.open(url, '_blank');
+  };
+
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="text-center">
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-indigo-600 mx-auto" />
+          <p className="mt-4 text-gray-600">Loading...</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50 p-4">
+      <h2 className="text-2xl font-bold text-center mb-6">Choose a Theme</h2>
+      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
+        {themes.map((theme) => (
+          <div key={theme.id} className="bg-white rounded shadow overflow-hidden">
+            <img src={theme.image} alt={theme.name} className="w-full h-32 object-cover" />
+            <div className="p-2 text-center">
+              <h3 className="text-sm font-medium mb-2">{theme.name}</h3>
+              <div className="flex justify-center space-x-2">
+                <button
+                  onClick={() => handlePreview(theme.previewUrl)}
+                  className="px-2 py-1 text-xs bg-gray-200 rounded"
+                >
+                  Preview
+                </button>
+                <button
+                  onClick={() => handleSelect(theme.id)}
+                  className="px-2 py-1 text-xs bg-indigo-600 text-white rounded"
+                >
+                  Select
+                </button>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+

--- a/server/models/Store.js
+++ b/server/models/Store.js
@@ -8,6 +8,8 @@ const StoreSchema = new mongoose.Schema({
   storeCity: String,
   storeAddress: String,
   businessCategory: String,
+  // Selected theme identifier
+  theme: String,
 });
 module.exports = mongoose.model('Store', StoreSchema);
 

--- a/server/routes/store.js
+++ b/server/routes/store.js
@@ -62,5 +62,20 @@ router.put("/update", protect, async (req, res) => {
   }
 });
 
+// Update store theme
+router.put("/theme", protect, async (req, res) => {
+  try {
+    const store = await Store.findOneAndUpdate(
+      { user: req.userId },
+      { theme: req.body.theme },
+      { new: true }
+    );
+    if (!store) return res.status(404).json({ msg: "No store" });
+    res.json({ msg: "Theme updated", store });
+  } catch (err) {
+    res.status(500).json({ msg: "Error updating theme" });
+  }
+});
+
 module.exports = router;
 


### PR DESCRIPTION
## Summary
- redirect new stores to a theme selection page
- allow choosing a theme and persist it on the store
- expose `/themes` page to browse and select themes

## Testing
- `cd server && npm test` (fails: Missing script: "test")
- `cd client && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688dc8661cb8832e8f75a5fe28cbc7cd