### PR TITLE
Connect dashboard with backend and protect routes

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,4 +1,4 @@
-import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
 import Home from './pages/Home';
 import Login from './pages/Login';
 import Signup from './pages/Signup';
@@ -10,6 +10,11 @@ import ForgotPassword from './pages/ForgotPassword';
 import ResetPassword from './pages/ResetPassword';
 import ThemeStore from './pages/ThemeStore';
 
+const PrivateRoute = ({ children }) => {
+  const isAuthenticated = localStorage.getItem('token');
+  return isAuthenticated ? children : <Navigate to="/login" />;
+};
+
 export default function App() {
   return (
     <Router>
@@ -17,11 +22,11 @@ export default function App() {
         <Route path="/" element={<Home />} />
         <Route path="/login" element={<Login />} />
         <Route path="/signup" element={<Signup />} />
-        <Route path="/dashboard" element={<Dashboard />} />
-        <Route path="/profile" element={<Profile />} />
-        <Route path="/analytics" element={<Analytics />} />
-        <Route path="/create-store" element={<CreateStore />} />
-        <Route path="/themes" element={<ThemeStore />} />
+        <Route path="/dashboard" element={<PrivateRoute><Dashboard /></PrivateRoute>} />
+        <Route path="/profile" element={<PrivateRoute><Profile /></PrivateRoute>} />
+        <Route path="/analytics" element={<PrivateRoute><Analytics /></PrivateRoute>} />
+        <Route path="/create-store" element={<PrivateRoute><CreateStore /></PrivateRoute>} />
+        <Route path="/themes" element={<PrivateRoute><ThemeStore /></PrivateRoute>} />
         <Route path="/forgot-password" element={<ForgotPassword />} />
         <Route path="/reset-password/:token" element={<ResetPassword />} />
       </Routes>

--- a/server/routes/user.js
+++ b/server/routes/user.js
@@ -1,0 +1,29 @@
+const express = require("express");
+const jwt = require("jsonwebtoken");
+const { getPublicKey } = require("../config/jwt");
+const User = require("../models/User");
+const router = express.Router();
+
+const protect = (req, res, next) => {
+  const token = req.headers.authorization?.split(" ")[1];
+  if (!token) return res.status(401).json({ msg: "No token" });
+  try {
+    const decoded = jwt.verify(token, getPublicKey(), { algorithm: 'RS256' });
+    req.userId = decoded.id;
+    next();
+  } catch {
+    res.status(401).json({ msg: "Invalid token" });
+  }
+};
+
+router.get("/me", protect, async (req, res) => {
+  try {
+    const user = await User.findById(req.userId).select('name email');
+    if (!user) return res.status(404).json({ msg: "User not found" });
+    res.json(user);
+  } catch (err) {
+    res.status(500).json({ msg: "Error fetching user" });
+  }
+});
+
+module.exports = router;

--- a/server/server.js
+++ b/server/server.js
@@ -14,6 +14,7 @@ app.use(express.json());
 // API Routes
 app.use("/api/auth", require("./routes/auth"));
 app.use("/api/store", require("./routes/store"));
+app.use("/api/user", require("./routes/user"));
 app.use("/api/password", require("./routes/forgot"));
 
 // Start Server


### PR DESCRIPTION
## Summary
- integrate dashboard with backend APIs for user and store info with token-based handling
- add user info endpoint and route protection to enforce authentication
- tweak dashboard grids for better mobile layout and implement logout navigation

## Testing
- `npm test` (frontend) *(fails: Missing script: "test")*
- `npm test` (backend) *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688dda42c060832e95567b282ed5098b