### PR TITLE
feat: add image upload pipeline

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -11,7 +11,8 @@
     "axios": "^1.6.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.22.1"
+    "react-router-dom": "^6.22.1",
+    "browser-image-compression": "^2.0.1"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.0.0",

--- a/client/src/components/ImageUpload.jsx
+++ b/client/src/components/ImageUpload.jsx
@@ -1,0 +1,70 @@
+import { useState, useRef } from 'react';
+import imageCompression from 'browser-image-compression';
+import axios from 'axios';
+
+const BASE_URL = import.meta.env.VITE_API_BASE_URL || (import.meta.env.DEV ? 'http://localhost:5000' : '');
+
+export default function ImageUpload({ label, value, onChange }) {
+  const [preview, setPreview] = useState(value);
+  const [uploading, setUploading] = useState(false);
+  const fileInput = useRef(null);
+
+  const handleFiles = async (files) => {
+    const file = files[0];
+    if (!file) return;
+    if (!file.type.startsWith('image/')) {
+      alert('Only images allowed');
+      return;
+    }
+    setUploading(true);
+    try {
+      const options = {
+        maxWidthOrHeight: 1024,
+        initialQuality: 0.8,
+        fileType: 'image/webp',
+        useWebWorker: true,
+      };
+      let compressed = await imageCompression(file, options);
+      if (compressed.size > 300 * 1024) {
+        alert('Image too large after compression');
+        setUploading(false);
+        return;
+      }
+      const formData = new FormData();
+      formData.append('image', compressed, 'image.webp');
+      const token = localStorage.getItem('token');
+      const res = await axios.post(`${BASE_URL}/api/upload/store-image`, formData, {
+        headers: { 'Content-Type': 'multipart/form-data', Authorization: `Bearer ${token}` },
+      });
+      setPreview(res.data.url);
+      onChange(res.data.url);
+    } catch (err) {
+      console.error(err);
+      alert('Upload failed');
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const onFileChange = (e) => handleFiles(e.target.files);
+
+  const handleDrop = (e) => {
+    e.preventDefault();
+    handleFiles(e.dataTransfer.files);
+  };
+
+  return (
+    <div className="mb-4">
+      {preview && <img src={preview} alt="preview" className="h-32 object-cover mb-2" />}
+      <div
+        className="border-dashed border-2 p-4 text-center cursor-pointer"
+        onClick={() => fileInput.current.click()}
+        onDragOver={(e) => e.preventDefault()}
+        onDrop={handleDrop}
+      >
+        {uploading ? 'Uploading...' : label}
+      </div>
+      <input type="file" accept="image/*" className="hidden" ref={fileInput} onChange={onFileChange} />
+    </div>
+  );
+}

--- a/client/src/pages/CreateStore.jsx
+++ b/client/src/pages/CreateStore.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { apiCall } from '../utils/api';
+import ImageUpload from '../components/ImageUpload';
 
 export default function CreateStore() {
   const [formData, setFormData] = useState({
@@ -10,7 +11,9 @@ export default function CreateStore() {
     storeWhatsapp: '',
     storeCity: '',
     storeAddress: '',
-    businessCategory: ''
+    businessCategory: '',
+    bannerImage: '',
+    logoImage: ''
   });
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
@@ -81,6 +84,17 @@ export default function CreateStore() {
                   {error}
                 </div>
               )}
+
+              <ImageUpload
+                label="Banner Image"
+                value={formData.bannerImage}
+                onChange={(url) => setFormData({ ...formData, bannerImage: url })}
+              />
+              <ImageUpload
+                label="Logo Image"
+                value={formData.logoImage}
+                onChange={(url) => setFormData({ ...formData, logoImage: url })}
+              />
 
               <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                 <div>

--- a/client/src/pages/Dashboard.jsx
+++ b/client/src/pages/Dashboard.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import axios from 'axios';
+import ImageUpload from '../components/ImageUpload';
 
 export default function Dashboard() {
   const navigate = useNavigate();
@@ -10,7 +11,13 @@ export default function Dashboard() {
   const [profileModal, setProfileModal] = useState(false);
   const [storeModal, setStoreModal] = useState(false);
   const [profileForm, setProfileForm] = useState({ name: '', email: '' });
-  const [storeForm, setStoreForm] = useState({ storeName: '', storeWhatsapp: '', storeAddress: '' });
+  const [storeForm, setStoreForm] = useState({
+    storeName: '',
+    storeWhatsapp: '',
+    storeAddress: '',
+    bannerImage: '',
+    logoImage: '',
+  });
   const [saving, setSaving] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
 
@@ -39,7 +46,9 @@ export default function Dashboard() {
         setStoreForm({
           storeName: storeRes.data.storeName || '',
           storeWhatsapp: storeRes.data.storeWhatsapp || '',
-          storeAddress: storeRes.data.storeAddress || ''
+          storeAddress: storeRes.data.storeAddress || '',
+          bannerImage: storeRes.data.bannerImage || '',
+          logoImage: storeRes.data.logoImage || '',
         });
       } catch (err) {
         if (err.response && err.response.status === 404) {
@@ -246,6 +255,16 @@ export default function Dashboard() {
         <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
           <div className="bg-white rounded-lg w-full h-full md:h-auto md:w-96 p-6 overflow-y-auto">
             <h2 className="text-xl font-semibold mb-4">{store ? 'Edit Store' : 'Create Store'}</h2>
+            <ImageUpload
+              label="Banner Image"
+              value={storeForm.bannerImage}
+              onChange={(url) => setStoreForm({ ...storeForm, bannerImage: url })}
+            />
+            <ImageUpload
+              label="Logo Image"
+              value={storeForm.logoImage}
+              onChange={(url) => setStoreForm({ ...storeForm, logoImage: url })}
+            />
             <label className="block mb-2 text-sm">Store Name</label>
             <input
               className="w-full border p-2 rounded mb-4"

--- a/server/models/Store.js
+++ b/server/models/Store.js
@@ -10,6 +10,8 @@ const StoreSchema = new mongoose.Schema({
   businessCategory: String,
   // Selected theme identifier
   theme: String,
+  bannerImage: String,
+  logoImage: String,
 });
 module.exports = mongoose.model('Store', StoreSchema);
 

--- a/server/package.json
+++ b/server/package.json
@@ -14,7 +14,9 @@
     "helmet": "^7.0.0",
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^7.8.7",
-    "nodemailer": "^7.0.5"
+    "nodemailer": "^7.0.5",
+    "multer": "^1.4.5-lts.1",
+    "sharp": "^0.33.3"
   },
   "devDependencies": {
     "nodemon": "^3.0.1"

--- a/server/routes/upload.js
+++ b/server/routes/upload.js
@@ -1,0 +1,56 @@
+const express = require('express');
+const path = require('path');
+const fs = require('fs');
+const multer = require('multer');
+const sharp = require('sharp');
+const protect = require('../middleware/auth');
+
+const router = express.Router();
+const storage = multer.memoryStorage();
+const upload = multer({
+  storage,
+  fileFilter: (req, file, cb) => {
+    if (!file.mimetype.startsWith('image/')) {
+      return cb(new Error('Only images allowed'));
+    }
+    cb(null, true);
+  }
+});
+
+router.post('/store-image', protect, upload.single('image'), async (req, res) => {
+  try {
+    const userId = req.user._id.toString();
+    const uploadsDir = path.join(__dirname, '..', 'uploads', 'storeImages', userId);
+    await fs.promises.mkdir(uploadsDir, { recursive: true });
+
+    const originalName = path.parse(req.file.originalname).name;
+    const filename = `${originalName}.webp`;
+    const filePath = path.join(uploadsDir, filename);
+
+    let quality = 80;
+    let buffer = await sharp(req.file.buffer)
+      .resize({ width: 1024, withoutEnlargement: true })
+      .webp({ quality })
+      .toBuffer();
+
+    while (buffer.length > 300 * 1024 && quality > 10) {
+      quality -= 10;
+      buffer = await sharp(req.file.buffer)
+        .resize({ width: 1024, withoutEnlargement: true })
+        .webp({ quality })
+        .toBuffer();
+    }
+
+    if (buffer.length > 300 * 1024) {
+      return res.status(400).json({ msg: 'Image too large' });
+    }
+
+    await sharp(buffer).toFile(filePath);
+    const url = `/uploads/storeImages/${userId}/${filename}`;
+    res.json({ url });
+  } catch (err) {
+    res.status(500).json({ msg: 'Error processing image' });
+  }
+});
+
+module.exports = router;

--- a/server/server.js
+++ b/server/server.js
@@ -16,6 +16,10 @@ app.use("/api/auth", require("./routes/auth"));
 app.use("/api/store", require("./routes/store"));
 app.use("/api/users", require("./routes/user"));
 app.use("/api/password", require("./routes/forgot"));
+app.use("/api/upload", require("./routes/upload"));
+
+// Serve uploaded images
+app.use("/uploads", express.static(path.join(__dirname, "uploads")));
 
 // Start Server
 const PORT = process.env.PORT || 5000;


### PR DESCRIPTION
## Summary
- add multer/sharp endpoint for optimized image uploads
- expose uploads directory and store image paths on Store schema
- add React component to compress and upload images for store forms

## Testing
- `npm test` (server) *(fails: Missing script "test")*
- `npm test` (client) *(fails: Missing script "test")*
- `npm run build` (client) *(fails: Rollup failed to resolve import "browser-image-compression")*

------
https://chatgpt.com/codex/tasks/task_e_688ef94c6ff0832e98538686d1918dd3