### PR TITLE
Implement theme management and domain mapping

### DIFF
--- a/moohaar-backend/package.json
+++ b/moohaar-backend/package.json
@@ -13,7 +13,8 @@
     "liquidjs": "^10.9.1",
     "mongoose": "^8.3.1",
     "multer": "^1.4.5-lts.1",
-    "unzipper": "^0.10.11"
+    "unzipper": "^0.10.11",
+    "jsonwebtoken": "^9.0.2"
   },
   "devDependencies": {
     "eslint": "^8.57.0",

--- a/moohaar-backend/src/controllers/store.controller.js
+++ b/moohaar-backend/src/controllers/store.controller.js
@@ -1,0 +1,19 @@
+import Store from '../models/store.model.js';
+
+// POST /api/store/:storeId/theme
+export const setActiveTheme = async (req, res) => {
+  try {
+    const { storeId } = req.params;
+    const { themeId } = req.body;
+    if (!themeId) {
+      return res.status(400).json({ message: 'themeId is required' });
+    }
+    await Store.findByIdAndUpdate(storeId, { activeTheme: themeId });
+    // 204 indicates success with no content
+    return res.status(204).send();
+  } catch (err) {
+    return res.status(500).json({ message: err.message });
+  }
+};
+
+export default { setActiveTheme };

--- a/moohaar-backend/src/middleware/auth.middleware.js
+++ b/moohaar-backend/src/middleware/auth.middleware.js
@@ -1,0 +1,39 @@
+import jwt from 'jsonwebtoken';
+import config from '../config/index.js';
+import Store from '../models/store.model.js';
+
+// JWT authentication middleware
+export const auth = (req, res, next) => {
+  const header = req.headers.authorization;
+  if (!header || !header.startsWith('Bearer ')) {
+    return res.status(401).json({ message: 'Unauthorized' });
+  }
+  const token = header.split(' ')[1];
+  try {
+    const decoded = jwt.verify(token, config.JWT_SECRET);
+    req.user = { id: decoded.id };
+    return next();
+  } catch (err) {
+    return res.status(401).json({ message: 'Invalid token' });
+  }
+};
+
+// Ensures the authenticated user owns the store
+export const authorizeStoreOwner = async (req, res, next) => {
+  try {
+    const { storeId } = req.params;
+    const store = await Store.findById(storeId);
+    if (!store) {
+      return res.status(404).json({ message: 'Store not found' });
+    }
+    if (store.ownerId.toString() !== req.user.id) {
+      return res.status(403).json({ message: 'Forbidden' });
+    }
+    req.store = store;
+    return next();
+  } catch (err) {
+    return res.status(500).json({ message: err.message });
+  }
+};
+
+export default { auth, authorizeStoreOwner };

--- a/moohaar-backend/src/models/store.model.js
+++ b/moohaar-backend/src/models/store.model.js
@@ -3,6 +3,11 @@ import mongoose from 'mongoose';
 const StoreSchema = new mongoose.Schema(
   {
     ownerId: { type: mongoose.Schema.Types.ObjectId, required: true },
+    // Store subdomain handle e.g. mystore.moohaar.com
+    handle: { type: String, unique: true, required: true },
+    // Optional user provided domain
+    customDomain: { type: String, unique: true, sparse: true },
+    // Reference to the currently active theme
     activeTheme: { type: mongoose.Schema.Types.ObjectId, ref: 'Theme' },
     config: { type: mongoose.Schema.Types.Mixed },
   },

--- a/moohaar-backend/src/routes/store.routes.js
+++ b/moohaar-backend/src/routes/store.routes.js
@@ -1,0 +1,10 @@
+import { Router } from 'express';
+import { setActiveTheme } from '../controllers/store.controller.js';
+import { auth, authorizeStoreOwner } from '../middleware/auth.middleware.js';
+
+const router = Router();
+
+// Assign active theme to store
+router.post('/:storeId/theme', auth, authorizeStoreOwner, setActiveTheme);
+
+export default router;

--- a/moohaar-backend/src/routes/theme.routes.js
+++ b/moohaar-backend/src/routes/theme.routes.js
@@ -1,13 +1,17 @@
 import { Router } from 'express';
 import multer from 'multer';
 import config from '../config/index.js';
-import { uploadTheme, listThemes, previewTheme } from '../controllers/theme.controller.js';
+import { listThemes, previewTheme, uploadTheme } from '../controllers/theme.controller.js';
+import { auth } from '../middleware/auth.middleware.js';
 
 const router = Router();
 const upload = multer({ dest: config.UPLOADS_PATH });
 
+// Optional upload route (not protected in requirements)
 router.post('/upload', upload.single('file'), uploadTheme);
-router.get('/', listThemes);
-router.get('/:id/preview', previewTheme);
+
+// Protected routes require valid JWT
+router.get('/', auth, listThemes);
+router.get('/:id/preview', auth, previewTheme);
 
 export default router;

--- a/moohaar-backend/src/server.js
+++ b/moohaar-backend/src/server.js
@@ -1,16 +1,82 @@
 import express from 'express';
+import fs from 'fs';
+import path from 'path';
 import config from './config/index.js';
 import connectDB from './services/db.service.js';
+import engine from './services/liquid.service.js';
+import Store from './models/store.model.js';
+import Theme from './models/theme.model.js';
 import themeRoutes from './routes/theme.routes.js';
+import storeRoutes from './routes/store.routes.js';
 import healthRoutes from './routes/health.routes.js';
 
 const app = express();
 
 app.use(express.json());
 
+// Domain-mapping middleware attaches store based on hostname
+app.use(async (req, res, next) => {
+  try {
+    const headerHost = req.headers.host;
+    if (headerHost) {
+      const host = headerHost.split(':')[0];
+      let store = await Store.findOne({ customDomain: host });
+      if (!store) {
+        const subdomain = host.split('.')[0];
+        store = await Store.findOne({ handle: subdomain });
+      }
+      if (store) {
+        req.store = store;
+      }
+    }
+  } catch (err) {
+    console.error('Domain mapping failed', err);
+  }
+  next();
+});
+
+// API routes
 app.use('/api/themes', themeRoutes);
+app.use('/api/store', storeRoutes);
 app.use('/health', healthRoutes);
 app.use('/themes', express.static(config.THEMES_PATH));
+
+// Public storefront - no auth required
+app.get('/*', async (req, res) => {
+  try {
+    const store = req.store;
+    if (!store || !store.activeTheme) {
+      return res.status(404).send('Store not found');
+    }
+    const theme = await Theme.findById(store.activeTheme);
+    if (!theme) {
+      return res.status(404).send('Theme not found');
+    }
+
+    // Determine template based on URL
+    let templateFile = 'index.liquid';
+    if (req.path !== '/' && req.path !== '') {
+      templateFile = 'product.liquid';
+    }
+
+    let templatePath = path.join(theme.paths.root, 'templates', templateFile);
+    if (!fs.existsSync(templatePath) && templateFile === 'product.liquid') {
+      templatePath = path.join(theme.paths.root, 'templates', 'index.liquid');
+    }
+    if (!fs.existsSync(templatePath)) {
+      return res.status(404).send('Template not found');
+    }
+
+    const template = fs.readFileSync(templatePath, 'utf-8');
+    const html = await engine.parseAndRender(template, {
+      store,
+      products: store.products || [],
+    });
+    return res.send(html);
+  } catch (err) {
+    return res.status(500).send('Server error');
+  }
+});
 
 const start = async () => {
   try {


### PR DESCRIPTION
## Summary
- extend Store model with subdomain handle, optional custom domain, and active theme reference
- add JWT auth and store owner authorization middleware
- implement theme pagination, preview rendering, and ability to assign active themes
- map incoming domains to stores and render storefront using Liquid templates

## Testing
- `npm test`
- `npm run lint` *(fails: Unable to resolve module 'jsonwebtoken' and import extension errors)*

------
https://chatgpt.com/codex/tasks/task_e_688f8efc1c64832e9109beb3f0aff91c