### PR TITLE
Add required metadata fields to Theme schema

### DIFF
--- a/moohaar-backend/src/models/theme.model.js
+++ b/moohaar-backend/src/models/theme.model.js
@@ -4,6 +4,12 @@ const ThemeSchema = new mongoose.Schema(
   {
     name: { type: String, required: true },
     author: { type: String },
+    // Semantic version of the theme
+    version: { type: String, required: true },
+    // Brief description of the theme
+    description: { type: String, required: true },
+    // URL pointing to a preview image
+    previewImage: { type: String, required: true },
     paths: {
       type: Map,
       of: String,


### PR DESCRIPTION
## Summary
- add required `version`, `description`, and `previewImage` fields to Theme schema

## Testing
- `npm test`
- `npm run lint` *(fails: 33 problems, existing issues)*

------
https://chatgpt.com/codex/tasks/task_e_6890e8ea0638832e9e390094314b0062