### PR TITLE
feat: add admin theme upload

### DIFF
--- a/moohaar-backend/src/middleware/auth.middleware.js
+++ b/moohaar-backend/src/middleware/auth.middleware.js
@@ -11,7 +11,7 @@ export const auth = (req, res, next) => {
   const token = header.split(' ')[1];
   try {
     const decoded = jwt.verify(token, config.JWT_SECRET);
-    req.user = { id: decoded.id };
+    req.user = { id: decoded.id, role: decoded.role };
     return next();
   } catch (err) {
     return res.status(401).json({ message: 'Invalid token' });
@@ -36,4 +36,12 @@ export const authorizeStoreOwner = async (req, res, next) => {
   }
 };
 
-export default { auth, authorizeStoreOwner };
+// Ensures the user has admin role
+export const authorizeAdmin = (req, res, next) => {
+  if (req.user && req.user.role === 'admin') {
+    return next();
+  }
+  return res.status(403).json({ message: 'Forbidden' });
+};
+
+export default { auth, authorizeStoreOwner, authorizeAdmin };

--- a/moohaar-backend/src/routes/theme.routes.js
+++ b/moohaar-backend/src/routes/theme.routes.js
@@ -1,14 +1,35 @@
 import { Router } from 'express';
 import multer from 'multer';
+import path from 'path';
 import config from '../config/index.js';
-import { listThemes, previewTheme, uploadTheme } from '../controllers/theme.controller.js';
-import { auth } from '../middleware/auth.middleware.js';
+import { createTheme, listThemes, previewTheme } from '../controllers/theme.controller.js';
+import { auth, authorizeAdmin } from '../middleware/auth.middleware.js';
 
 const router = Router();
-const upload = multer({ dest: config.UPLOADS_PATH });
 
-// Optional upload route (not protected in requirements)
-router.post('/upload', upload.single('file'), uploadTheme);
+// Multer configuration: single ZIP up to 5MB
+const upload = multer({
+  dest: config.UPLOADS_PATH,
+  limits: { fileSize: 5 * 1024 * 1024 },
+  fileFilter: (req, file, cb) => {
+    const ext = path.extname(file.originalname).toLowerCase();
+    if (ext === '.zip') {
+      cb(null, true);
+    } else {
+      cb(new Error('Only ZIP files are allowed'));
+    }
+  },
+});
+
+// Admin create theme
+router.post('/', auth, authorizeAdmin, (req, res) => {
+  upload.single('file')(req, res, (err) => {
+    if (err) {
+      return res.status(400).json({ message: err.message });
+    }
+    return createTheme(req, res);
+  });
+});
 
 // Protected routes require valid JWT
 router.get('/', auth, listThemes);


### PR DESCRIPTION
## Summary
- add admin-only theme creation endpoint that unzips, validates, and stores theme metadata
- enforce authorization with new `authorizeAdmin` middleware
- wire route with multer zip upload handling

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected use of file extension "js" for "../config/index.js", etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6890f22237f8832e836e44b964829817