### PR TITLE
feat: add theme update and delete endpoints

### DIFF
--- a/moohaar-backend/src/controllers/theme.controller.js
+++ b/moohaar-backend/src/controllers/theme.controller.js
@@ -121,3 +121,99 @@ export const previewTheme = async (req, res) => {
     return res.status(500).json({ message: err.message });
   }
 };
+
+// PUT /api/themes/:id
+export const updateTheme = async (req, res) => {
+  try {
+    const { id } = req.params;
+
+    const theme = await Theme.findById(id);
+    if (!theme) {
+      if (req.file) {
+        await fsp.unlink(req.file.path);
+      }
+      return res.status(404).json({ message: 'Theme not found' });
+    }
+
+    if (!req.file) {
+      return res.status(400).json({ message: 'No file uploaded' });
+    }
+
+    const themeDir = path.join(config.THEMES_PATH, id);
+
+    // Remove existing directory and recreate
+    await fsp.rm(themeDir, { recursive: true, force: true });
+    await fsp.mkdir(themeDir, { recursive: true });
+
+    // Unzip uploaded file into the theme directory
+    await fs
+      .createReadStream(req.file.path)
+      .pipe(unzipper.Extract({ path: themeDir }))
+      .promise();
+
+    // Validate required directories
+    const requiredDirs = ['layout', 'templates', 'assets'];
+    try {
+      requiredDirs.forEach((dir) => {
+        const dirPath = path.join(themeDir, dir);
+        if (!fs.existsSync(dirPath)) {
+          throw new Error(`${dir} folder missing in theme`);
+        }
+      });
+    } catch (validationErr) {
+      return res.status(400).json({ message: validationErr.message });
+    }
+
+    // Validate config.json
+    const configPath = path.join(themeDir, 'config.json');
+    if (!fs.existsSync(configPath)) {
+      return res.status(400).json({ message: 'config.json missing in theme' });
+    }
+
+    const meta = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    try {
+      const requiredFields = ['name', 'handle', 'version', 'description', 'previewImage'];
+      requiredFields.forEach((field) => {
+        if (typeof meta[field] !== 'string' || !meta[field]) {
+          throw new Error(`Invalid config.json: missing ${field}`);
+        }
+      });
+    } catch (validationErr) {
+      return res.status(400).json({ message: validationErr.message });
+    }
+
+    // Update theme metadata
+    theme.version = meta.version;
+    theme.description = meta.description;
+    theme.previewImage = meta.previewImage;
+    theme.paths = { root: themeDir };
+    theme.metadata = meta;
+    await theme.save();
+
+    // Clean up uploaded zip
+    await fsp.unlink(req.file.path);
+
+    return res.status(200).json(theme);
+  } catch (err) {
+    return res.status(500).json({ message: err.message });
+  }
+};
+
+// DELETE /api/themes/:id
+export const deleteTheme = async (req, res) => {
+  try {
+    const { id } = req.params;
+    const theme = await Theme.findById(id);
+    if (!theme) {
+      return res.status(404).json({ message: 'Theme not found' });
+    }
+
+    const themeDir = path.join(config.THEMES_PATH, id);
+    await fsp.rm(themeDir, { recursive: true, force: true });
+    await theme.deleteOne();
+
+    return res.status(204).send();
+  } catch (err) {
+    return res.status(500).json({ message: err.message });
+  }
+};

--- a/moohaar-backend/src/routes/theme.routes.js
+++ b/moohaar-backend/src/routes/theme.routes.js
@@ -2,7 +2,13 @@ import { Router } from 'express';
 import multer from 'multer';
 import path from 'path';
 import config from '../config/index.js';
-import { createTheme, listThemes, previewTheme } from '../controllers/theme.controller.js';
+import {
+  createTheme,
+  listThemes,
+  previewTheme,
+  updateTheme,
+  deleteTheme,
+} from '../controllers/theme.controller.js';
 import { auth, authorizeAdmin } from '../middleware/auth.middleware.js';
 
 const router = Router();
@@ -30,6 +36,19 @@ router.post('/', auth, authorizeAdmin, (req, res) => {
     return createTheme(req, res);
   });
 });
+
+// Admin update theme
+router.put('/:id', auth, authorizeAdmin, (req, res) => {
+  upload.single('file')(req, res, (err) => {
+    if (err) {
+      return res.status(400).json({ message: err.message });
+    }
+    return updateTheme(req, res);
+  });
+});
+
+// Admin delete theme
+router.delete('/:id', auth, authorizeAdmin, deleteTheme);
 
 // Protected routes require valid JWT
 router.get('/', auth, listThemes);


### PR DESCRIPTION
## Summary
- add controller logic for updating and deleting themes
- wire up PUT and DELETE theme routes with admin auth and ZIP upload

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected use of file extension)*

------
https://chatgpt.com/codex/tasks/task_e_68918da60dac832ead1608f785908523