### PR TITLE
chore(server): add lint and format tooling

### DIFF
--- a/server/.eslintrc.json
+++ b/server/.eslintrc.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["airbnb-base", "prettier"],
+  "env": { "browser": true, "es2022": true }
+}

--- a/server/.prettierrc
+++ b/server/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "es5"
+}

--- a/server/package.json
+++ b/server/package.json
@@ -2,10 +2,17 @@
   "name": "server",
   "version": "1.0.0",
   "private": true,
+  "engines": {
+    "node": ">=20.0.0"
+  },
   "scripts": {
     "dev": "nodemon server.js",
     "start": "node server.js",
-    "test": "echo \"No tests yet\" && exit 0"
+    "test": "echo \"No tests yet\" && exit 0",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "format": "prettier --write .",
+    "build": "npm run lint && npm run build:prod"
   },
   "dependencies": {
     "bcryptjs": "^3.0.2",
@@ -20,6 +27,11 @@
     "sharp": "^0.33.3"
   },
   "devDependencies": {
-    "nodemon": "^3.0.1"
+    "nodemon": "^3.0.1",
+    "eslint": "^8.57.0",
+    "eslint-config-airbnb-base": "^15.0.0",
+    "eslint-plugin-import": "^2.29.1",
+    "prettier": "^3.2.5",
+    "eslint-config-prettier": "^9.1.0"
   }
 }


### PR DESCRIPTION
## Summary
- enforce Node 20+ for server
- set up ESLint and Prettier configs
- add lint, format, and build scripts

## Testing
- `npm test`
- `npm run lint` *(fails: no-console, import/newline-after-import, consistent-return, no-underscore-dangle, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6891cbba441c832e81e406771091fb62