### PR TITLE
chore: align backend linting and formatting with client

### DIFF
--- a/moohaar-backend/.eslintrc.json
+++ b/moohaar-backend/.eslintrc.json
@@ -1,12 +1,5 @@
 {
-  "env": {
-    "es2021": true,
-    "node": true
-  },
   "extends": ["airbnb-base", "prettier"],
-  "parserOptions": {
-    "ecmaVersion": "latest",
-    "sourceType": "module"
-  },
-  "rules": {}
+  "env": { "browser": true, "es2022": true }
 }
+

--- a/moohaar-backend/.prettierrc
+++ b/moohaar-backend/.prettierrc
@@ -1,1 +1,6 @@
-{}
+{
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "es5"
+}
+

--- a/moohaar-backend/package.json
+++ b/moohaar-backend/package.json
@@ -2,9 +2,14 @@
   "name": "moohaar-backend",
   "version": "1.0.0",
   "type": "module",
+  "engines": {
+    "node": ">=20.0.0"
+  },
   "scripts": {
     "start": "node src/server.js",
     "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "format": "prettier --write .",
     "test": "echo \"No tests specified\" && exit 0"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- add Node 20 engine requirement and lint/format scripts to backend package
- copy client ESLint and Prettier configs to backend for consistent style

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected use of file extension "js" and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6891ce8d72c4832eac1f2b3dcdb2d945