### PR TITLE
feat: add route lazy loading and image optimization

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,15 +1,18 @@
+import React from 'react';
 import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
 import Home from './pages/Home';
 import Login from './pages/Login';
 import Signup from './pages/Signup';
-import Dashboard from './pages/Dashboard';
+// Lazily load heavy pages for route-based code splitting
+const Dashboard = React.lazy(() => import('./pages/Dashboard'));
 import Profile from './pages/Profile';
 import Analytics from './pages/Analytics';
 import CreateStore from './pages/CreateStore';
 import ForgotPassword from './pages/ForgotPassword';
 import ResetPassword from './pages/ResetPassword';
-import ThemeStore from './pages/ThemeStore';
-import ThemeUpload from './pages/ThemeUpload';
+const ThemeStore = React.lazy(() => import('./pages/ThemeStore'));
+const ThemeUpload = React.lazy(() => import('./pages/ThemeUpload'));
+import Loading from './components/Loading';
 
 const PrivateRoute = ({ children }) => {
   const isAuthenticated = localStorage.getItem('token');
@@ -19,19 +22,22 @@ const PrivateRoute = ({ children }) => {
 export default function App() {
   return (
     <Router>
-      <Routes>
-        <Route path="/" element={<Home />} />
-        <Route path="/login" element={<Login />} />
-        <Route path="/signup" element={<Signup />} />
-        <Route path="/dashboard" element={<PrivateRoute><Dashboard /></PrivateRoute>} />
-        <Route path="/profile" element={<PrivateRoute><Profile /></PrivateRoute>} />
-        <Route path="/analytics" element={<PrivateRoute><Analytics /></PrivateRoute>} />
-        <Route path="/create-store" element={<PrivateRoute><CreateStore /></PrivateRoute>} />
-        <Route path="/themes" element={<ThemeStore />} />
-        <Route path="/upload-theme" element={<PrivateRoute><ThemeUpload /></PrivateRoute>} />
-        <Route path="/forgot-password" element={<ForgotPassword />} />
-        <Route path="/reset-password/:token" element={<ResetPassword />} />
-      </Routes>
+      {/* Display fallback while lazy components load */}
+      <React.Suspense fallback={<Loading />}>
+        <Routes>
+          <Route path="/" element={<Home />} />
+          <Route path="/login" element={<Login />} />
+          <Route path="/signup" element={<Signup />} />
+          <Route path="/dashboard" element={<PrivateRoute><Dashboard /></PrivateRoute>} />
+          <Route path="/profile" element={<PrivateRoute><Profile /></PrivateRoute>} />
+          <Route path="/analytics" element={<PrivateRoute><Analytics /></PrivateRoute>} />
+          <Route path="/create-store" element={<PrivateRoute><CreateStore /></PrivateRoute>} />
+          <Route path="/themes" element={<ThemeStore />} />
+          <Route path="/upload-theme" element={<PrivateRoute><ThemeUpload /></PrivateRoute>} />
+          <Route path="/forgot-password" element={<ForgotPassword />} />
+          <Route path="/reset-password/:token" element={<ResetPassword />} />
+        </Routes>
+      </React.Suspense>
     </Router>
   );
 }

--- a/client/src/components/Loading.jsx
+++ b/client/src/components/Loading.jsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return <div className="flex items-center justify-center h-full">Loading...</div>;
+}

--- a/client/src/components/ThemeCard.jsx
+++ b/client/src/components/ThemeCard.jsx
@@ -3,8 +3,9 @@ export default function ThemeCard({ theme, onPreview, onSelect }) {
     <div className="bg-white rounded shadow p-4 flex flex-col space-y-2">
       <img
         src={theme.previewImage}
-        alt={theme.name}
-        className="w-full h-48 object-cover rounded"
+        alt={`${theme.name} preview`}
+        loading="lazy" // Lazy-load images for better performance
+        className="w-full h-auto rounded"
       />
       <h3 className="text-lg font-semibold">{theme.name}</h3>
       <p className="text-sm text-gray-600 flex-1">{theme.description}</p>


### PR DESCRIPTION
## Summary
- lazy-load Dashboard, ThemeStore, and ThemeUpload routes with Suspense fallback
- add reusable Loading component for route-based code splitting
- defer off-screen image loading in ThemeCard

## Testing
- `npm test`
- `npm run lint` *(fails: Parsing error: Unexpected token import)*

------
https://chatgpt.com/codex/tasks/task_e_68923a43a1fc832e82c2f7c1552e4468