### PR TITLE
feat: add testing ci docker and logging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,52 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Install backend deps
+        run: npm install
+        working-directory: moohaar-backend
+      - name: Lint backend
+        run: npm run lint
+        working-directory: moohaar-backend
+      - name: Test backend
+        run: npm test
+        working-directory: moohaar-backend
+      - name: Upload backend coverage
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: backend-coverage
+          path: moohaar-backend/coverage
+      - name: Install client deps
+        run: npm install
+        working-directory: client
+      - name: Lint client
+        run: npm run lint
+        working-directory: client
+      - name: Test client
+        run: npm test
+        working-directory: client
+      - name: E2E tests
+        run: npm run test:e2e
+        working-directory: client
+      - name: Upload client coverage
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: client-coverage
+          path: client/coverage
+      - name: Build frontend
+        run: npm run build:prod
+        working-directory: client

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,11 @@ client/dist/
 server/node_modules/
 client/node_modules/
 
+# Test coverage
+coverage/
+moohaar-backend/coverage/
+client/coverage/
+
 # OS
 .DS_Store
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,18 @@ This repository contains a React frontend (Vite) and an Express backend with Mon
 - `npm run dev` – start server with nodemon
 - `npm run start` – start server
 
+## Testing
+
+Backend and frontend projects use Jest with an 80% global coverage threshold. Example tests exist in `moohaar-backend/src/controllers/__tests__` and `client/src/components/__tests__`.
+
+- Backend: `npm test` from `moohaar-backend`
+- Frontend unit tests: `npm test` from `client`
+- Frontend end-to-end tests: `npm run test:e2e` from `client`
+
+## Docker
+
+Dockerfiles are provided for the client and backend. To run both services together use `docker-compose up --build` which respects environment variables like `BACKEND_PORT` and `CLIENT_PORT`.
+
 See `client/package.json` and `server/package.json` for dependencies.
 
 ## Environment Variables

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:20-alpine AS build
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY . .
+RUN npm run build:prod
+
+FROM node:20-alpine
+WORKDIR /app
+COPY --from=build /app/dist ./dist
+RUN npm install -g serve
+EXPOSE 4173
+CMD ["serve", "-s", "dist", "-l", "4173"]

--- a/client/babel.config.cjs
+++ b/client/babel.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  presets: [
+    ['@babel/preset-env', { targets: { node: 'current' } }],
+    ['@babel/preset-react', { runtime: 'automatic' }],
+  ],
+};

--- a/client/cypress.config.js
+++ b/client/cypress.config.js
@@ -1,0 +1,8 @@
+const { defineConfig } = require('cypress');
+
+module.exports = defineConfig({
+  e2e: {
+    baseUrl: 'http://localhost:4173',
+    supportFile: false,
+  },
+});

--- a/client/cypress/e2e/theme-marketplace.cy.js
+++ b/client/cypress/e2e/theme-marketplace.cy.js
@@ -1,0 +1,9 @@
+describe('Theme marketplace flow', () => {
+  it('browses, previews, selects, and views storefront', () => {
+    cy.visit('/');
+    cy.contains('Themes').click();
+    cy.get('button').contains('Preview').first().click();
+    cy.contains('Select').click();
+    cy.url().should('include', '/');
+  });
+});

--- a/client/jest.config.cjs
+++ b/client/jest.config.cjs
@@ -1,0 +1,15 @@
+module.exports = {
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['@testing-library/jest-dom'],
+  transform: {
+    '^.+\\.[jt]sx?$': 'babel-jest',
+  },
+  coverageThreshold: {
+    global: {
+      branches: 80,
+      functions: 80,
+      lines: 80,
+      statements: 80,
+    },
+  },
+};

--- a/client/package.json
+++ b/client/package.json
@@ -10,7 +10,8 @@
     "build": "npm run lint && npm run build:prod",
     "build:prod": "vite build",
     "start": "vite preview",
-    "test": "echo \"No tests yet\" && exit 0",
+    "test": "jest --coverage",
+    "test:e2e": "cypress run",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write ."
@@ -33,6 +34,14 @@
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-plugin-import": "^2.29.1",
     "prettier": "^3.2.5",
-    "eslint-config-prettier": "^9.1.0"
+    "eslint-config-prettier": "^9.1.0",
+    "@babel/preset-env": "^7.24.0",
+    "@babel/preset-react": "^7.24.0",
+    "@testing-library/jest-dom": "^6.2.0",
+    "@testing-library/react": "^14.2.1",
+    "babel-jest": "^29.7.0",
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0",
+    "cypress": "^13.7.0"
   }
 }

--- a/client/src/components/__tests__/ThemeCard.test.jsx
+++ b/client/src/components/__tests__/ThemeCard.test.jsx
@@ -1,0 +1,19 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import ThemeCard from '../ThemeCard.jsx';
+
+const theme = {
+  _id: '1',
+  name: 'Test Theme',
+  description: 'A test theme',
+  previewImage: 'test.png',
+};
+
+test('triggers callbacks on actions', () => {
+  const onPreview = jest.fn();
+  const onSelect = jest.fn();
+  render(<ThemeCard theme={theme} onPreview={onPreview} onSelect={onSelect} />);
+  fireEvent.click(screen.getByText('Preview'));
+  expect(onPreview).toHaveBeenCalledWith('1');
+  fireEvent.click(screen.getByText('Select'));
+  expect(onSelect).toHaveBeenCalledWith('1');
+});

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '3'
+services:
+  backend:
+    build: ./moohaar-backend
+    ports:
+      - "${BACKEND_PORT:-3000}:3000"
+    environment:
+      - PORT=3000
+      - MONGODB_URI=${MONGODB_URI}
+  client:
+    build: ./client
+    ports:
+      - "${CLIENT_PORT:-4173}:4173"
+    environment:
+      - VITE_API_URL=http://localhost:3000
+    depends_on:
+      - backend

--- a/moohaar-backend/Dockerfile
+++ b/moohaar-backend/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package*.json ./
+RUN npm install --production
+COPY src ./src
+COPY themes ./themes
+ENV NODE_ENV=production
+EXPOSE 3000
+CMD ["node", "src/server.js"]

--- a/moohaar-backend/jest.config.js
+++ b/moohaar-backend/jest.config.js
@@ -1,0 +1,11 @@
+export default {
+  testEnvironment: 'node',
+  coverageThreshold: {
+    global: {
+      branches: 80,
+      functions: 80,
+      lines: 80,
+      statements: 80,
+    },
+  },
+};

--- a/moohaar-backend/package.json
+++ b/moohaar-backend/package.json
@@ -7,10 +7,10 @@
   },
   "scripts": {
     "start": "node src/server.js",
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --runInBand --coverage",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "format": "prettier --write .",
-    "test": "echo \"No tests specified\" && exit 0"
+    "format": "prettier --write ."
   },
   "dependencies": {
     "dompurify": "^3.0.6",
@@ -23,7 +23,8 @@
     "liquidjs": "^10.9.1",
     "mongoose": "^8.3.1",
     "multer": "^1.4.5-lts.1",
-    "unzipper": "^0.10.11"
+    "unzipper": "^0.10.11",
+    "winston": "^3.11.0"
   },
   "devDependencies": {
     "eslint": "^8.57.0",
@@ -31,6 +32,9 @@
     "eslint-plugin-import": "^2.29.1",
     "eslint-config-prettier": "^9.1.0",
     "prettier": "^3.2.5",
-    "pm2": "^5.3.0"
+    "pm2": "^5.3.0",
+    "jest": "^29.7.0",
+    "supertest": "^6.3.4",
+    "mongodb-memory-server": "^8.16.1"
   }
 }

--- a/moohaar-backend/src/controllers/__tests__/health.controller.test.js
+++ b/moohaar-backend/src/controllers/__tests__/health.controller.test.js
@@ -1,0 +1,27 @@
+import request from 'supertest';
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import app from '../../server.js';
+
+let mongoServer;
+
+beforeAll(async () => {
+  mongoServer = await MongoMemoryServer.create();
+  const uri = mongoServer.getUri();
+  await mongoose.connect(uri, { dbName: 'test' });
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongoServer.stop();
+});
+
+describe('GET /health', () => {
+  it('returns service health information', async () => {
+    const res = await request(app).get('/health');
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('uptime');
+    expect(res.body).toHaveProperty('mongo', 'connected');
+    expect(res.body).toHaveProperty('memoryUsage');
+  });
+});

--- a/moohaar-backend/src/controllers/health.controller.js
+++ b/moohaar-backend/src/controllers/health.controller.js
@@ -6,11 +6,11 @@ import Theme from '../models/theme.model.js';
 export const healthCheck = async (req, res, next) => {
   try {
     const mongo = mongoose.connection.readyState === 1 ? 'connected' : 'disconnected';
-    const themesLoaded = await Theme.countDocuments();
+    const memoryUsage = process.memoryUsage().rss;
     return res.json({
       uptime: process.uptime(),
       mongo,
-      themesLoaded,
+      memoryUsage,
     });
   } catch (err) {
     return next(err);

--- a/moohaar-backend/src/middleware/errorHandler.js
+++ b/moohaar-backend/src/middleware/errorHandler.js
@@ -1,7 +1,9 @@
+import logger from '../utils/logger.js';
+
 // Centralized error handling middleware
 // Logs the stack and sends consistent JSON responses
 export default (err, req, res, _next) => {
-  console.error(err.stack);
+  logger.error({ message: err.message, stack: err.stack });
   if (err.name === 'ValidationError') {
     return res.status(400).json({ message: err.message });
   }

--- a/moohaar-backend/src/utils/logger.js
+++ b/moohaar-backend/src/utils/logger.js
@@ -1,0 +1,18 @@
+import winston from 'winston';
+
+const transports = [
+  new winston.transports.File({ filename: 'logs/combined.log' }),
+  new winston.transports.File({ filename: 'logs/error.log', level: 'error' }),
+];
+
+if (process.env.NODE_ENV !== 'production') {
+  transports.push(new winston.transports.Console({ format: winston.format.simple() }));
+}
+
+const logger = winston.createLogger({
+  level: 'info',
+  format: winston.format.json(),
+  transports,
+});
+
+export default logger;


### PR DESCRIPTION
## Summary
- add jest testing and coverage for backend and frontend
- implement cypress e2e spec
- set up github actions workflow
- add dockerfiles and compose configuration
- add winston logging and health metrics endpoint

## Testing
- `npm test` (backend) *(fails: Cannot find module '/workspace/code-boy/moohaar-backend/node_modules/jest/bin/jest.js')*
- `npm test` (client) *(fails: jest: not found)*
- `npm run test:e2e` (client) *(fails: cypress: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6892dfad9638832e8126dbae4eb808eb