### PR TITLE
Expose unzip utility as named export with malicious content error

### DIFF
--- a/moohaar-backend/src/controllers/theme.controller.js
+++ b/moohaar-backend/src/controllers/theme.controller.js
@@ -9,8 +9,9 @@ import { auth, authorizeAdmin } from '../middleware/auth.middleware';
 import logger from '../utils/logger';
 
 // Utility for safe extraction and scanning of theme archives
-import unzipTheme, {
+import {
   MaliciousContentError,
+  unzipFile,
 } from '../utils/unzip.util';
 
 // Multer configuration: store uploads in configured path with size and type checks
@@ -40,7 +41,7 @@ router.post(
 
       // Extract uploaded ZIP safely then remove the temporary archive
       try {
-        await unzipTheme(req.file.path, destPath);
+        await unzipFile(req.file.path, destPath);
       } catch (err) {
         await fs.unlink(req.file.path);
         if (err instanceof MaliciousContentError) {
@@ -188,7 +189,7 @@ router.put(
       // Remove existing directory and extract new one
       await fs.rm(themeDir, { recursive: true, force: true });
       try {
-        await unzipTheme(req.file.path, themeDir);
+        await unzipFile(req.file.path, themeDir);
       } catch (err) {
         await fs.unlink(req.file.path);
         if (err instanceof MaliciousContentError) {

--- a/moohaar-backend/src/utils/unzip.util.js
+++ b/moohaar-backend/src/utils/unzip.util.js
@@ -1,22 +1,59 @@
 import fs from 'fs';
-import fsp from 'fs/promises';
 import path from 'path';
-import unzipper from 'unzipper';
+import { Open } from 'unzipper';
+import logger from './logger';
 
-const REQUIRED_DIRS = ['templates'];
+// Allowed file extensions for extraction
+const VALID_EXT = /\.(liquid|js|css|png|jpe?g|webp|svg)$/i;
+// Patterns that are not allowed within extracted files
+const DISALLOWED_PATTERN = /<script>|eval\(|document\.|window\./i;
 
-const unzipTheme = async (zipPath, destPath) => {
-  await fs
-    .createReadStream(zipPath)
-    .pipe(unzipper.Extract({ path: destPath }))
-    .promise();
+class MaliciousContentError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'MaliciousContentError';
+  }
+}
 
-  await Promise.all(
-    REQUIRED_DIRS.map(async (dir) => {
-      const dirPath = path.join(destPath, dir);
-      await fsp.access(dirPath);
-    })
-  );
-};
+/**
+ * Safely extracts a zip archive into the destination directory.
+ *
+ * Paths are normalized to prevent directory traversal attacks and only
+ * whitelisted file types are written to disk. Certain strings commonly used
+ * in XSS attacks will trigger a MaliciousContentError and abort extraction.
+ *
+ * @param {string} zipPath - Path to the zip file to extract.
+ * @param {string} destPath - Directory to extract files into.
+ * @throws {MaliciousContentError} when disallowed content is found.
+ */
+async function unzipFile(zipPath, destPath) {
+  const absoluteDest = path.resolve(destPath);
 
-export default unzipTheme;
+  const directory = await Open.file(zipPath);
+  for (const file of directory.files) {
+    const entryPath = path.normalize(path.join(absoluteDest, file.path));
+
+    if (!entryPath.startsWith(absoluteDest)) {
+      throw new Error('Invalid path');
+    }
+
+    if (file.type === 'Directory' || !VALID_EXT.test(file.path)) {
+      continue;
+    }
+
+    const fileBuffer = await file.buffer();
+    const fileContent = fileBuffer.toString('utf8');
+    if (DISALLOWED_PATTERN.test(fileContent)) {
+      logger.warn(`Malicious content detected in ${entryPath}`);
+      await fs.promises.rm(absoluteDest, { recursive: true, force: true });
+      throw new MaliciousContentError(
+        `Malicious content detected in file ${file.path}`
+      );
+    }
+
+    await fs.promises.mkdir(path.dirname(entryPath), { recursive: true });
+    await fs.promises.writeFile(entryPath, fileBuffer);
+  }
+}
+
+export { MaliciousContentError, unzipFile };


### PR DESCRIPTION
## Summary
- add `MaliciousContentError` and secure `unzipFile` helper as named exports
- update theme controller to use new named exports

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893196e58d0832e97bb31cadacc0889