### PR TITLE
Add CSRF protection and restricted CORS

### DIFF
--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -1,8 +1,18 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import axios from 'axios';
 import App from './App';
 import './index.css';
 import ErrorBoundary from './components/ErrorBoundary';
+
+axios.defaults.withCredentials = true;
+axios.defaults.xsrfCookieName = 'XSRF-TOKEN';
+axios.defaults.xsrfHeaderName = 'X-CSRF-Token';
+
+// Prime CSRF token cookie for the session
+if (process.env.NODE_ENV !== 'test') {
+  axios.get('/api/csrf-token');
+}
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>

--- a/moohaar-backend/src/__tests__/csrf.test.js
+++ b/moohaar-backend/src/__tests__/csrf.test.js
@@ -1,0 +1,45 @@
+/* eslint-env jest */
+import request from 'supertest';
+import fs from 'fs/promises';
+import path from 'path';
+import os from 'os';
+import { jest } from '@jest/globals';
+
+// Mock Store model to avoid database dependency
+jest.unstable_mockModule('../models/store.model.js', () => ({
+  default: { findOne: jest.fn().mockResolvedValue(null) },
+}));
+
+const { app } = await import('../server.js');
+
+let tmpRoot;
+
+beforeAll(async () => {
+  process.env.NODE_ENV = 'test';
+  tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'csrf-test-'));
+  process.env.THEMES_PATH = path.join(tmpRoot, 'themes');
+  process.env.UPLOADS_PATH = path.join(tmpRoot, 'uploads');
+  await fs.mkdir(process.env.THEMES_PATH);
+  await fs.mkdir(process.env.UPLOADS_PATH);
+});
+
+afterAll(async () => {
+  await fs.rm(tmpRoot, { recursive: true, force: true });
+});
+
+describe('CSRF protection', () => {
+  it('rejects POST without CSRF token', async () => {
+    const res = await request(app).post('/api/themes');
+    expect(res.status).toBe(403);
+  });
+
+  it('allows request with valid CSRF token (then fails auth)', async () => {
+    const agent = request.agent(app);
+    const tokenRes = await agent.get('/api/csrf-token');
+    const { csrfToken } = tokenRes.body;
+    const res = await agent
+      .post('/api/themes')
+      .set('X-CSRF-Token', csrfToken);
+    expect(res.status).not.toBe(403);
+  });
+});


### PR DESCRIPTION
## Summary
- restrict CORS to Moohaar subdomains and verified custom domains
- add CSRF protection with token endpoint and enforcement middleware
- frontend automatically fetches and sends CSRF token for state-changing requests

## Testing
- `cd moohaar-backend && npm test`
- `cd client && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68931e8da4a4832e8278aa854e61eec7