### PR TITLE
feat: run client e2e against render

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,9 +38,13 @@ jobs:
       - name: Test client
         run: npm test
         working-directory: client
-      - name: E2E tests
-        run: npm run test:e2e
-        working-directory: client
+      - name: Run client E2E against Render
+        working-directory: ./client
+        env:
+          RENDER_URL: https://moohaarapp.onrender.com
+        run: |
+          npm ci
+          npx cypress run
       - name: Upload client coverage
         if: always()
         uses: actions/upload-artifact@v4

--- a/client/cypress.config.js
+++ b/client/cypress.config.js
@@ -1,8 +1,9 @@
-const { defineConfig } = require('cypress');
+const baseUrl = process.env.RENDER_URL || 'https://moohaarapp.onrender.com';
 
-module.exports = defineConfig({
+module.exports = {
   e2e: {
-    baseUrl: 'http://localhost:4173',
-    supportFile: false,
+    baseUrl,
+    specPattern: 'cypress/e2e/**/*.cy.js',
+    supportFile: 'cypress/support/index.js',
   },
-});
+};

--- a/client/cypress/support/index.js
+++ b/client/cypress/support/index.js
@@ -1,0 +1,1 @@
+// Custom Cypress support commands can be added here.

--- a/moohaar-backend/src/server.js
+++ b/moohaar-backend/src/server.js
@@ -118,12 +118,13 @@ app.use((req, _res, next) => {
 
 // Restrictive CORS handling
 const moohaarOrigin = /^https:\/\/([a-z0-9-]+\.)*moohaar\.com$/i;
+const allowedOrigins = ['https://moohaarapp.onrender.com'];
 app.use(async (req, res, next) => {
   const { origin } = req.headers;
   if (!origin) return next();
 
   let allowed = false;
-  if (moohaarOrigin.test(origin)) {
+  if (allowedOrigins.includes(origin) || moohaarOrigin.test(origin)) {
     allowed = true;
   } else {
     try {


### PR DESCRIPTION
## Summary
- configure Cypress to use Render URL
- run client E2E in CI against Render
- allow Render domain in backend CORS

## Testing
- `npm test` (backend)
- `npm run lint` (backend)
- `npm test` (client)
- `npm run lint` (client)
- `npx cypress run` *(fails: missing Xvfb)*
- `sudo apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68938624c268832eaa186c6b17d72777