### PR TITLE
feat: add user authentication and role handling

### DIFF
--- a/moohaar-backend/package.json
+++ b/moohaar-backend/package.json
@@ -18,6 +18,7 @@
     "express": "^4.19.2",
     "express-rate-limit": "^7.1.5",
     "helmet": "^7.1.2",
+    "bcrypt": "^5.1.0",
     "jsonwebtoken": "^9.0.2",
     "jsdom": "^24.0.0",
     "elastic-apm-node": "^4.6.0",

--- a/moohaar-backend/src/controllers/auth.controller.js
+++ b/moohaar-backend/src/controllers/auth.controller.js
@@ -1,0 +1,66 @@
+import jwt from 'jsonwebtoken';
+import User from '../models/user.model';
+import config from '../config/index';
+import { hashPassword, comparePassword } from '../utils/password.util';
+
+// POST /api/auth/register
+export const register = async (req, res, next) => {
+  try {
+    const { email, password, role } = req.body;
+    if (!email || !password) {
+      return res.status(400).json({ message: 'email and password are required' });
+    }
+    const existing = await User.findOne({ email });
+    if (existing) {
+      return res.status(409).json({ message: 'email already exists' });
+    }
+    const passwordHash = await hashPassword(password);
+    const user = await User.create({ email, passwordHash, role });
+    return res.status(201).json({ id: user.id, email: user.email, role: user.role });
+  } catch (err) {
+    return next(err);
+  }
+};
+
+// POST /api/auth/login
+export const login = async (req, res, next) => {
+  try {
+    const { email, password } = req.body;
+    if (!email || !password) {
+      return res.status(400).json({ message: 'email and password are required' });
+    }
+    const user = await User.findOne({ email });
+    if (!user) {
+      return res.status(401).json({ message: 'Invalid credentials' });
+    }
+    const isValid = await comparePassword(password, user.passwordHash);
+    if (!isValid) {
+      return res.status(401).json({ message: 'Invalid credentials' });
+    }
+    const token = jwt.sign(
+      { userId: user.id, role: user.role },
+      config.JWT_SECRET,
+      { expiresIn: '1d' },
+    );
+    res.cookie('token', token, {
+      httpOnly: true,
+      sameSite: 'strict',
+      secure: process.env.NODE_ENV === 'production',
+    });
+    return res.json({ id: user.id, email: user.email, role: user.role });
+  } catch (err) {
+    return next(err);
+  }
+};
+
+// POST /api/auth/logout
+export const logout = (req, res) => {
+  res.clearCookie('token', {
+    httpOnly: true,
+    sameSite: 'strict',
+    secure: process.env.NODE_ENV === 'production',
+  });
+  return res.status(204).send();
+};
+
+export default { register, login, logout };

--- a/moohaar-backend/src/middleware/auth.middleware.js
+++ b/moohaar-backend/src/middleware/auth.middleware.js
@@ -4,14 +4,20 @@ import Store from '../models/store.model';
 
 // JWT authentication middleware
 export const auth = (req, res, next) => {
-  const { authorization: header } = req.headers;
-  if (!header || !header.startsWith('Bearer ')) {
+  const { token } = req.cookies || {};
+  let jwtToken = token;
+  if (!jwtToken) {
+    const { authorization: header } = req.headers;
+    if (header && header.startsWith('Bearer ')) {
+      jwtToken = header.split(' ')[1];
+    }
+  }
+  if (!jwtToken) {
     return res.status(401).json({ message: 'Unauthorized' });
   }
-  const token = header.split(' ')[1];
   try {
-    const decoded = jwt.verify(token, config.JWT_SECRET);
-    req.user = { id: decoded.id, role: decoded.role };
+    const decoded = jwt.verify(jwtToken, config.JWT_SECRET);
+    req.user = { id: decoded.userId, role: decoded.role };
     return next();
   } catch (err) {
     return res.status(401).json({ message: 'Invalid token' });

--- a/moohaar-backend/src/models/user.model.js
+++ b/moohaar-backend/src/models/user.model.js
@@ -1,0 +1,16 @@
+import mongoose from 'mongoose';
+
+const UserSchema = new mongoose.Schema(
+  {
+    email: { type: String, unique: true, required: true },
+    passwordHash: { type: String, required: true },
+    role: {
+      type: String,
+      enum: ['admin', 'merchant'],
+      default: 'merchant',
+    },
+  },
+  { timestamps: true }
+);
+
+export default mongoose.model('User', UserSchema);

--- a/moohaar-backend/src/routes/auth.routes.js
+++ b/moohaar-backend/src/routes/auth.routes.js
@@ -1,0 +1,10 @@
+import { Router } from 'express';
+import { register, login, logout } from '../controllers/auth.controller';
+
+const router = Router();
+
+router.post('/register', register);
+router.post('/login', login);
+router.post('/logout', logout);
+
+export default router;

--- a/moohaar-backend/src/server.js
+++ b/moohaar-backend/src/server.js
@@ -14,6 +14,8 @@ import Theme from './models/theme.model';
 import themeRoutes from './controllers/theme.controller';
 import storeRoutes from './routes/store.routes';
 import healthRoutes from './routes/health.routes';
+import authRoutes from './routes/auth.routes';
+import { auth, authorizeAdmin } from './middleware/auth.middleware';
 import errorHandler from './middleware/errorHandler';
 import logger from './utils/logger';
 import { initCache, getCache, setCache } from './services/cache.service';
@@ -221,6 +223,8 @@ app.use(async (req, res, next) => {
 });
 
 // API routes
+app.use('/api/auth', authRoutes);
+app.use('/api/admin', auth, authorizeAdmin);
 app.use('/api/themes', themeRoutes);
 app.use('/api/store', storeRoutes);
 app.use('/health', healthRoutes);

--- a/moohaar-backend/src/utils/password.util.js
+++ b/moohaar-backend/src/utils/password.util.js
@@ -1,0 +1,34 @@
+import crypto from 'crypto';
+
+export const hashPassword = async (password) => {
+  try {
+    const bcrypt = (await import('bcrypt')).default;
+    return await bcrypt.hash(password, 10);
+  } catch (err) {
+    return new Promise((resolve, reject) => {
+      const salt = crypto.randomBytes(16).toString('hex');
+      crypto.scrypt(password, salt, 64, (scryptErr, derivedKey) => {
+        if (scryptErr) return reject(scryptErr);
+        return resolve(`${salt}:${derivedKey.toString('hex')}`);
+      });
+    });
+  }
+};
+
+export const comparePassword = async (password, hash) => {
+  try {
+    const bcrypt = (await import('bcrypt')).default;
+    return await bcrypt.compare(password, hash);
+  } catch (err) {
+    return new Promise((resolve, reject) => {
+      const [salt, key] = hash.split(':');
+      if (!salt || !key) return resolve(false);
+      crypto.scrypt(password, salt, 64, (scryptErr, derivedKey) => {
+        if (scryptErr) return reject(scryptErr);
+        return resolve(key === derivedKey.toString('hex'));
+      });
+    });
+  }
+};
+
+export default { hashPassword, comparePassword };


### PR DESCRIPTION
## Summary
- add user model with roles
- implement auth controller with register, login, logout
- verify JWT cookies and guard admin routes

## Testing
- `cd moohaar-backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689433b5afa0832e8c941254b5244f25