### PR TITLE
feat: scaffold admin sections

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -8,6 +8,9 @@ const Dashboard = React.lazy(() => import('./pages/Dashboard'));
 const AdminDashboard = React.lazy(() => import('./admin/pages/Dashboard'));
 const StoresList = React.lazy(() => import('./admin/pages/StoresList'));
 const StoreDetails = React.lazy(() => import('./admin/pages/StoreDetails'));
+const Users = React.lazy(() => import('./admin/pages/Users'));
+const ThemeAdmin = React.lazy(() => import('./admin/pages/ThemeAdmin'));
+const Settings = React.lazy(() => import('./admin/pages/Settings'));
 import Profile from './pages/Profile';
 import Analytics from './pages/Analytics';
 import CreateStore from './pages/CreateStore';
@@ -51,6 +54,9 @@ export default function App() {
           <Route path="/admin" element={<AdminRoute><AdminDashboard /></AdminRoute>} />
           <Route path="/admin/stores" element={<AdminRoute><StoresList /></AdminRoute>} />
           <Route path="/admin/stores/:storeId" element={<AdminRoute><StoreDetails /></AdminRoute>} />
+          <Route path="/admin/users" element={<AdminRoute><Users /></AdminRoute>} />
+          <Route path="/admin/themes" element={<AdminRoute><ThemeAdmin /></AdminRoute>} />
+          <Route path="/admin/settings" element={<AdminRoute><Settings /></AdminRoute>} />
           <Route path="/upload-theme" element={<PrivateRoute><ThemeUpload /></PrivateRoute>} />
           <Route path="/forgot-password" element={<ForgotPassword />} />
           <Route path="/reset-password/:token" element={<ResetPassword />} />

--- a/client/src/admin/components/RoleToggleModal.jsx
+++ b/client/src/admin/components/RoleToggleModal.jsx
@@ -1,0 +1,15 @@
+export default function RoleToggleModal({ user, onClose }) {
+  if (!user) return null;
+
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50">
+      <div className="bg-white p-4 rounded space-y-4">
+        <div className="text-lg">Edit Roles for {user.email}</div>
+        {/* TODO: role selection and status toggle */}
+        <button onClick={onClose} className="px-4 py-2 bg-gray-200 rounded">
+          Close
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/client/src/admin/components/Sidebar.jsx
+++ b/client/src/admin/components/Sidebar.jsx
@@ -1,7 +1,15 @@
+import { Link } from 'react-router-dom';
+
 export default function Sidebar() {
   return (
     <aside className="w-64 bg-gray-800 text-white p-4 hidden sm:block">
-      {/* sidebar placeholder */}
+      <nav className="space-y-2">
+        <Link to="/admin" className="block hover:underline">Dashboard</Link>
+        <Link to="/admin/stores" className="block hover:underline">Stores</Link>
+        <Link to="/admin/users" className="block hover:underline">Users</Link>
+        <Link to="/admin/themes" className="block hover:underline">Themes</Link>
+        <Link to="/admin/settings" className="block hover:underline">Settings</Link>
+      </nav>
     </aside>
   );
 }

--- a/client/src/admin/components/UserTable.jsx
+++ b/client/src/admin/components/UserTable.jsx
@@ -1,0 +1,42 @@
+import { useState } from 'react';
+
+export default function UserTable({ onEdit }) {
+  const [search, setSearch] = useState('');
+
+  return (
+    <div>
+      <input
+        type="text"
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        placeholder="Search users..."
+        className="w-full border rounded p-2 mb-4"
+      />
+      <table className="w-full">
+        <thead>
+          <tr className="text-left">
+            <th>Email</th>
+            <th>Role</th>
+            <th>Status</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>user@example.com</td>
+            <td>user</td>
+            <td>active</td>
+            <td>
+              <button
+                onClick={() => onEdit({ id: 1, email: 'user@example.com' })}
+                className="text-blue-600"
+              >
+                Edit
+              </button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/client/src/admin/pages/Settings.jsx
+++ b/client/src/admin/pages/Settings.jsx
@@ -1,0 +1,25 @@
+import AdminLayout from '../layout/AdminLayout';
+
+export default function Settings() {
+  return (
+    <AdminLayout>
+      <div className="space-y-6">
+        <h1 className="text-xl">Global Settings</h1>
+        <section>
+          <h2 className="font-semibold mb-2">Default Theme</h2>
+          <select className="border p-2 w-full">
+            <option>Select theme</option>
+          </select>
+        </section>
+        <section>
+          <h2 className="font-semibold mb-2">Upload Size Limit</h2>
+          <input type="number" className="border p-2 w-full" />
+        </section>
+        <section>
+          <h2 className="font-semibold mb-2">Feature Flags</h2>
+          {/* TODO: feature flag toggles */}
+        </section>
+      </div>
+    </AdminLayout>
+  );
+}

--- a/client/src/admin/pages/ThemeAdmin.jsx
+++ b/client/src/admin/pages/ThemeAdmin.jsx
@@ -1,0 +1,12 @@
+import AdminLayout from '../layout/AdminLayout';
+
+export default function ThemeAdmin() {
+  return (
+    <AdminLayout>
+      <div className="space-y-4">
+        <h1 className="text-xl">Theme Marketplace</h1>
+        {/* TODO: list and manage themes */}
+      </div>
+    </AdminLayout>
+  );
+}

--- a/client/src/admin/pages/Users.jsx
+++ b/client/src/admin/pages/Users.jsx
@@ -1,0 +1,20 @@
+import { useState } from 'react';
+import AdminLayout from '../layout/AdminLayout';
+import UserTable from '../components/UserTable';
+import RoleToggleModal from '../components/RoleToggleModal';
+
+export default function Users() {
+  const [activeUser, setActiveUser] = useState(null);
+
+  return (
+    <AdminLayout>
+      <div className="space-y-4">
+        <h1 className="text-xl">User Management</h1>
+        <UserTable onEdit={setActiveUser} />
+        {activeUser && (
+          <RoleToggleModal user={activeUser} onClose={() => setActiveUser(null)} />
+        )}
+      </div>
+    </AdminLayout>
+  );
+}

--- a/moohaar-backend/src/controllers/admin.controller.js
+++ b/moohaar-backend/src/controllers/admin.controller.js
@@ -1,4 +1,38 @@
 export const getDashboard = (_req, res) =>
   res.json({ message: 'admin dashboard placeholder' });
 
-export default { getDashboard };
+export const listUsers = (_req, res) =>
+  res.json({ users: [], total: 0 });
+
+export const updateUser = (_req, res) =>
+  res.json({ message: 'update user placeholder' });
+
+export const listThemes = (_req, res) =>
+  res.json({ themes: [] });
+
+export const approveTheme = (_req, res) =>
+  res.json({ message: 'approve theme placeholder' });
+
+export const updateTheme = (_req, res) =>
+  res.json({ message: 'update theme placeholder' });
+
+export const disableTheme = (_req, res) =>
+  res.json({ message: 'disable theme placeholder' });
+
+export const getSettings = (_req, res) =>
+  res.json({ settings: {} });
+
+export const updateSettings = (_req, res) =>
+  res.json({ message: 'update settings placeholder' });
+
+export default {
+  getDashboard,
+  listUsers,
+  updateUser,
+  listThemes,
+  approveTheme,
+  updateTheme,
+  disableTheme,
+  getSettings,
+  updateSettings,
+};

--- a/moohaar-backend/src/routes/admin.routes.js
+++ b/moohaar-backend/src/routes/admin.routes.js
@@ -1,8 +1,32 @@
 import { Router } from 'express';
-import { getDashboard } from '../controllers/admin.controller';
+import {
+  getDashboard,
+  listUsers,
+  updateUser,
+  listThemes,
+  approveTheme,
+  updateTheme,
+  disableTheme,
+  getSettings,
+  updateSettings,
+} from '../controllers/admin.controller';
 
 const router = Router();
 
 router.get('/dashboard', getDashboard);
+
+// User management
+router.get('/users', listUsers);
+router.patch('/users/:userId', updateUser);
+
+// Theme marketplace management
+router.get('/themes', listThemes);
+router.post('/themes/:themeId/approve', approveTheme);
+router.put('/themes/:themeId', updateTheme);
+router.patch('/themes/:themeId/disable', disableTheme);
+
+// Global settings
+router.get('/settings', getSettings);
+router.put('/settings', updateSettings);
 
 export default router;


### PR DESCRIPTION
## Summary
- scaffold user, theme, and settings admin pages
- add user table and role modal components
- stub admin routes/controllers for users, themes, and global settings
- wire sidebar and router to new admin sections

## Testing
- `cd client && npm test`
- `cd moohaar-backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68948b25b97c832eb0af4d0d8404c564