### PR TITLE
Add build:prod script to server package

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -12,6 +12,7 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
+    "build:prod": "echo \"No build step configured\"",
     "build": "npm run lint && npm run build:prod"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- add placeholder `build:prod` script so build command references a valid task

## Testing
- `npm run build` *(fails: 65 problems (59 errors, 6 warnings))*


------
https://chatgpt.com/codex/tasks/task_e_6894d4927d38832ea7910a49df80f450