### PR TITLE
feat(auth): add refresh token rotation

### DIFF
--- a/moohaar-backend/src/controllers/__tests__/auth.refresh.test.js
+++ b/moohaar-backend/src/controllers/__tests__/auth.refresh.test.js
@@ -1,0 +1,86 @@
+/* eslint-env jest */
+/* eslint-disable import/no-extraneous-dependencies */
+import request from 'supertest';
+import express from 'express';
+import cookie from 'cookie';
+import { jest } from '@jest/globals';
+import { hashPassword } from '../../utils/password.util.js';
+
+let app;
+let User;
+
+beforeAll(async () => {
+  process.env.JWT_SECRET = 'testsecret';
+  process.env.NODE_ENV = 'test';
+
+  const users = [];
+  class MockUser {
+    constructor(data) {
+      Object.assign(this, data);
+    }
+    static async findOne({ email }) {
+      return users.find((u) => u.email === email) || null;
+    }
+    static async findById(id) {
+      return users.find((u) => u.id === id) || null;
+    }
+    static async create(data) {
+      const user = new MockUser({ ...data, id: `${users.length + 1}` });
+      users.push(user);
+      return user;
+    }
+    async save() {
+      const idx = users.findIndex((u) => u.id === this.id);
+      if (idx !== -1) {
+        users[idx] = this;
+      }
+    }
+  }
+
+  jest.unstable_mockModule('../../models/user.model.js', () => ({ default: MockUser }));
+  const { default: authRoutes } = await import('../../routes/auth.routes.js');
+  ({ default: User } = await import('../../models/user.model.js'));
+
+  app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    const { cookie: raw } = req.headers;
+    req.cookies = raw ? cookie.parse(raw) : {};
+    next();
+  });
+  app.use('/api/auth', authRoutes);
+
+  const passwordHash = await hashPassword('password123');
+  await User.create({ email: 'test@example.com', passwordHash, role: 'merchant' });
+});
+
+describe('POST /api/auth/refresh', () => {
+  it('rotates refresh token and issues new access token', async () => {
+    const loginRes = await request(app)
+      .post('/api/auth/login')
+      .send({ email: 'test@example.com', password: 'password123' });
+    expect(loginRes.status).toBe(200);
+    const cookies = loginRes.headers['set-cookie'];
+    const refreshCookie = cookies.find((c) => c.startsWith('refreshToken='));
+    expect(refreshCookie).toBeDefined();
+    const refreshToken = cookie.parse(refreshCookie.split(';')[0]).refreshToken;
+
+    const first = await request(app)
+      .post('/api/auth/refresh')
+      .set('Cookie', `refreshToken=${refreshToken}`);
+    expect(first.status).toBe(200);
+    const newCookies = first.headers['set-cookie'];
+    const newRefreshCookie = newCookies.find((c) => c.startsWith('refreshToken='));
+    const newRefreshToken = cookie.parse(newRefreshCookie.split(';')[0]).refreshToken;
+
+    const reuse = await request(app)
+      .post('/api/auth/refresh')
+      .set('Cookie', `refreshToken=${refreshToken}`);
+    expect(reuse.status).toBe(401);
+
+    const second = await request(app)
+      .post('/api/auth/refresh')
+      .set('Cookie', `refreshToken=${newRefreshToken}`);
+    expect(second.status).toBe(200);
+  });
+});

--- a/moohaar-backend/src/models/user.model.js
+++ b/moohaar-backend/src/models/user.model.js
@@ -9,6 +9,7 @@ const UserSchema = new mongoose.Schema(
       enum: ['admin', 'merchant'],
       default: 'merchant',
     },
+    refreshTokenHash: { type: String },
   },
   { timestamps: true }
 );

--- a/moohaar-backend/src/routes/auth.routes.js
+++ b/moohaar-backend/src/routes/auth.routes.js
@@ -1,10 +1,11 @@
 import { Router } from 'express';
-import { register, login, logout } from '../controllers/auth.controller';
+import { register, login, logout, refresh } from '../controllers/auth.controller';
 
 const router = Router();
 
 router.post('/register', register);
 router.post('/login', login);
 router.post('/logout', logout);
+router.post('/refresh', refresh);
 
 export default router;


### PR DESCRIPTION
## Summary
- issue refresh token during login and store hashed token
- add /api/auth/refresh endpoint to rotate refresh tokens and issue new JWT
- cover refresh flow with tests

## Testing
- `cd moohaar-backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6894d4b01004832e8424d07b207ecd82