### PR TITLE
feat: add request validation

### DIFF
--- a/moohaar-backend/src/controllers/auth.controller.js
+++ b/moohaar-backend/src/controllers/auth.controller.js
@@ -1,57 +1,72 @@
 import jwt from 'jsonwebtoken';
+import Joi from 'joi'; // eslint-disable-line import/no-unresolved
+import validate from '../middleware/validate';
 import User from '../models/user.model';
 import config from '../config/index';
 import { hashPassword, comparePassword } from '../utils/password.util';
 
+const registerSchema = Joi.object({
+  email: Joi.string().email().required(),
+  password: Joi.string().required(),
+  role: Joi.string().optional(),
+});
+
+const loginSchema = Joi.object({
+  email: Joi.string().email().required(),
+  password: Joi.string().required(),
+});
+
 // POST /api/auth/register
-export const register = async (req, res, next) => {
-  try {
-    const { email, password, role } = req.body;
-    if (!email || !password) {
-      return res.status(400).json({ message: 'email and password are required' });
+export const register = [
+  validate(registerSchema),
+  async (req, res, next) => {
+    try {
+      const { email, password, role } = req.body;
+      const existing = await User.findOne({ email });
+      if (existing) {
+        return res.status(409).json({ message: 'email already exists' });
+      }
+      const passwordHash = await hashPassword(password);
+      const user = await User.create({ email, passwordHash, role });
+      return res
+        .status(201)
+        .json({ id: user.id, email: user.email, role: user.role });
+    } catch (err) {
+      return next(err);
     }
-    const existing = await User.findOne({ email });
-    if (existing) {
-      return res.status(409).json({ message: 'email already exists' });
-    }
-    const passwordHash = await hashPassword(password);
-    const user = await User.create({ email, passwordHash, role });
-    return res.status(201).json({ id: user.id, email: user.email, role: user.role });
-  } catch (err) {
-    return next(err);
-  }
-};
+  },
+];
 
 // POST /api/auth/login
-export const login = async (req, res, next) => {
-  try {
-    const { email, password } = req.body;
-    if (!email || !password) {
-      return res.status(400).json({ message: 'email and password are required' });
+export const login = [
+  validate(loginSchema),
+  async (req, res, next) => {
+    try {
+      const { email, password } = req.body;
+      const user = await User.findOne({ email });
+      if (!user) {
+        return res.status(401).json({ message: 'Invalid credentials' });
+      }
+      const isValid = await comparePassword(password, user.passwordHash);
+      if (!isValid) {
+        return res.status(401).json({ message: 'Invalid credentials' });
+      }
+      const token = jwt.sign(
+        { userId: user.id, role: user.role },
+        config.JWT_SECRET,
+        { expiresIn: '1d' },
+      );
+      res.cookie('token', token, {
+        httpOnly: true,
+        sameSite: 'strict',
+        secure: process.env.NODE_ENV === 'production',
+      });
+      return res.json({ id: user.id, email: user.email, role: user.role });
+    } catch (err) {
+      return next(err);
     }
-    const user = await User.findOne({ email });
-    if (!user) {
-      return res.status(401).json({ message: 'Invalid credentials' });
-    }
-    const isValid = await comparePassword(password, user.passwordHash);
-    if (!isValid) {
-      return res.status(401).json({ message: 'Invalid credentials' });
-    }
-    const token = jwt.sign(
-      { userId: user.id, role: user.role },
-      config.JWT_SECRET,
-      { expiresIn: '1d' },
-    );
-    res.cookie('token', token, {
-      httpOnly: true,
-      sameSite: 'strict',
-      secure: process.env.NODE_ENV === 'production',
-    });
-    return res.json({ id: user.id, email: user.email, role: user.role });
-  } catch (err) {
-    return next(err);
-  }
-};
+  },
+];
 
 // POST /api/auth/logout
 export const logout = (req, res) => {

--- a/moohaar-backend/src/middleware/validate.js
+++ b/moohaar-backend/src/middleware/validate.js
@@ -1,18 +1,25 @@
 import Joi from 'joi'; // eslint-disable-line import/no-unresolved
 
 // Joi validation middleware factory
-// Validates req.body against the provided schema and
-// returns 400 with message on failure.
-export default (schema) => (req, res, next) => {
+// Validates a request property against the provided schema and
+// forwards errors to the central error handler.
+//
+// property - Which request property to validate (e.g. 'body', 'query')
+//            defaults to 'body'.
+export default (schema, property = 'body') => (req, res, next) => {
   // Ensure a proper Joi schema is supplied
   if (!Joi.isSchema(schema)) {
     return next(new Error('Invalid validation schema'));
   }
-  const { error } = schema.validate(req.body);
+
+  const { error, value } = schema.validate(req[property]);
   if (error) {
     // Forward validation error to central error handler
     error.name = 'ValidationError';
     return next(error);
   }
+
+  // Replace the original value with the sanitized version
+  req[property] = value;
   return next();
 };


### PR DESCRIPTION
## Summary
- extend validation middleware to handle body or query data and sanitize results
- add Joi schemas and validation to auth register/login endpoints
- validate pagination query on theme listing

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected use of file extension "js" etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6894d4b5badc832ea18e45ed62e5716a