### PR TITLE
feat: protect admin routes

### DIFF
--- a/client/src/components/AdminRoute.jsx
+++ b/client/src/components/AdminRoute.jsx
@@ -1,3 +1,21 @@
+import { useEffect, useState } from 'react';
+import { Navigate } from 'react-router-dom';
+import axios from 'axios';
+import Loading from './Loading.jsx';
+
 export default function AdminRoute({ children }) {
-  return children;
+  const [allowed, setAllowed] = useState(false);
+  const [checking, setChecking] = useState(true);
+
+  useEffect(() => {
+    axios.get('/api/auth/me', { withCredentials: true })
+      .then((res) => {
+        if (res.data.role === 'admin') setAllowed(true);
+      })
+      .catch(() => setAllowed(false))
+      .finally(() => setChecking(false));
+  }, []);
+
+  if (checking) return <Loading />;
+  return allowed ? children : <Navigate to="/login" />;
 }

--- a/client/src/components/__tests__/AdminRoute.test.jsx
+++ b/client/src/components/__tests__/AdminRoute.test.jsx
@@ -1,0 +1,56 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import axios from 'axios';
+import AdminRoute from '../AdminRoute.jsx';
+
+jest.mock('axios');
+
+describe('AdminRoute', () => {
+  it('redirects non-admin users to login', async () => {
+    axios.get.mockResolvedValueOnce({ data: { role: 'user' } });
+
+    render(
+      <MemoryRouter initialEntries={['/admin']}>
+        <Routes>
+          <Route path="/login" element={<div>Login Page</div>} />
+          <Route
+            path="/admin"
+            element={(
+              <AdminRoute>
+                <div>Admin Content</div>
+              </AdminRoute>
+            )}
+          />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Login Page')).toBeInTheDocument();
+    });
+  });
+
+  it('allows admin users to proceed', async () => {
+    axios.get.mockResolvedValueOnce({ data: { role: 'admin' } });
+
+    render(
+      <MemoryRouter initialEntries={['/admin']}>
+        <Routes>
+          <Route path="/login" element={<div>Login Page</div>} />
+          <Route
+            path="/admin"
+            element={(
+              <AdminRoute>
+                <div>Admin Content</div>
+              </AdminRoute>
+            )}
+          />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Admin Content')).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add admin role check to AdminRoute and redirect unauthorized users to login
- test admin-only access behavior

## Testing
- `cd client && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6894d4bbc2dc832ea79baeb920090b13