### PR TITLE
Add compound indexes for order and pageview models

### DIFF
--- a/moohaar-backend/src/models/order.model.js
+++ b/moohaar-backend/src/models/order.model.js
@@ -18,4 +18,6 @@ const OrderSchema = new mongoose.Schema(
   { timestamps: { createdAt: true, updatedAt: false } },
 );
 
+OrderSchema.index({ storeId: 1, createdAt: 1 });
+
 export default mongoose.model('Order', OrderSchema);

--- a/moohaar-backend/src/models/pageview.model.js
+++ b/moohaar-backend/src/models/pageview.model.js
@@ -15,4 +15,7 @@ const PageViewSchema = new mongoose.Schema(
   { versionKey: false },
 );
 
+PageViewSchema.index({ storeId: 1, timestamp: 1 });
+PageViewSchema.index({ storeId: 1, sessionId: 1 });
+
 export default mongoose.model('PageView', PageViewSchema);


### PR DESCRIPTION
## Summary
- add compound index on storeId and createdAt for orders
- add compound indexes on storeId with timestamp and sessionId for pageviews

## Testing
- `npm test`
- `npx eslint src/models/order.model.js src/models/pageview.model.js`
- `node --input-type=module <sync indexes script>` *(fails: MongoMemoryServer missing libcrypto.so.1.1)*

------
https://chatgpt.com/codex/tasks/task_e_6894d4c10114832ea1f988f8ec950422