### PR TITLE
refactor: add useApi loading states to admin pages

### DIFF
--- a/client/src/admin/components/UserTable.jsx
+++ b/client/src/admin/components/UserTable.jsx
@@ -1,42 +1,28 @@
-import { useState } from 'react';
-
-export default function UserTable({ onEdit }) {
-  const [search, setSearch] = useState('');
-
+export default function UserTable({ users = [], onEdit }) {
   return (
-    <div>
-      <input
-        type="text"
-        value={search}
-        onChange={(e) => setSearch(e.target.value)}
-        placeholder="Search users..."
-        className="w-full border rounded p-2 mb-4"
-      />
-      <table className="w-full">
-        <thead>
-          <tr className="text-left">
-            <th>Email</th>
-            <th>Role</th>
-            <th>Status</th>
-            <th></th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>user@example.com</td>
-            <td>user</td>
-            <td>active</td>
+    <table className="w-full">
+      <thead>
+        <tr className="text-left">
+          <th>Email</th>
+          <th>Role</th>
+          <th>Status</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        {users.map((user) => (
+          <tr key={user.id}>
+            <td>{user.email}</td>
+            <td>{user.role}</td>
+            <td>{user.status}</td>
             <td>
-              <button
-                onClick={() => onEdit({ id: 1, email: 'user@example.com' })}
-                className="text-blue-600"
-              >
+              <button onClick={() => onEdit(user)} className="text-blue-600">
                 Edit
               </button>
             </td>
           </tr>
-        </tbody>
-      </table>
-    </div>
+        ))}
+      </tbody>
+    </table>
   );
 }

--- a/client/src/admin/pages/StoreDetails.jsx
+++ b/client/src/admin/pages/StoreDetails.jsx
@@ -1,7 +1,9 @@
-import { useEffect, useState } from 'react';
+import { useState, useCallback } from 'react';
 import { useParams } from 'react-router-dom';
-import axios from 'axios';
 import AdminLayout from '../layout/AdminLayout';
+import Loading from '../../components/Loading';
+import useApi from '../../hooks/useApi';
+import { getStoreMetrics } from '../../services/api';
 import {
   LineChart,
   Line,
@@ -21,24 +23,21 @@ export default function StoreDetails() {
     .toISOString()
     .split('T')[0];
 
-  const [metrics, setMetrics] = useState({});
   const [dateFrom, setDateFrom] = useState(sevenDaysAgo);
   const [dateTo, setDateTo] = useState(today);
+  const [reload, setReload] = useState(0);
 
-  const fetchMetrics = () => {
-    axios
-      .get(`/api/admin/stores/${storeId}/metrics`, {
-        params: { from: dateFrom, to: dateTo }
-      })
-      .then((res) => setMetrics(res.data || {}))
-      .catch(() => setMetrics({}));
-  };
-
-  useEffect(() => {
-    if (storeId) fetchMetrics();
+  const fetchMetrics = useCallback((_, config) => {
+    if (!storeId) return Promise.resolve({});
+    return getStoreMetrics(storeId, dateFrom, dateTo, config);
   }, [storeId, dateFrom, dateTo]);
 
-  const combinedSessions = (metrics.sessionsByDay || []).map((d, i) => ({
+    const { data, loading, error } = useApi(fetchMetrics, reload);
+    const metrics = data || {};
+
+    const handleRefresh = () => setReload((r) => r + 1);
+
+    const combinedSessions = (metrics.sessionsByDay || []).map((d, i) => ({
     date: d.date,
     sessions: d.sessions,
     bounce: metrics.bounceByDay?.[i]?.bounce
@@ -61,75 +60,83 @@ export default function StoreDetails() {
             className="border p-2 rounded"
           />
           <button
-            onClick={fetchMetrics}
+            onClick={handleRefresh}
             className="px-4 py-2 bg-blue-600 text-white rounded"
           >
             Refresh
           </button>
         </div>
+        {error && (
+          <p className="text-red-500 text-center">{error.message || 'Failed to load metrics'}</p>
+        )}
+        {loading ? (
+          <Loading />
+        ) : (
+          <>
+            <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-4">
+              <div className="bg-white p-4 rounded shadow text-center">
+                <div className="text-sm text-gray-500">Total Sales</div>
+                <div className="text-xl font-semibold">
+                  {metrics.salesTotal ?? '-'}
+                </div>
+              </div>
+              <div className="bg-white p-4 rounded shadow text-center">
+                <div className="text-sm text-gray-500">Total Sessions</div>
+                <div className="text-xl font-semibold">
+                  {metrics.sessionsTotal ?? '-'}
+                </div>
+              </div>
+              <div className="bg-white p-4 rounded shadow text-center">
+                <div className="text-sm text-gray-500">Bounce Rate</div>
+                <div className="text-xl font-semibold">
+                  {metrics.bounceRate ?? '-'}
+                </div>
+              </div>
+              <div className="bg-white p-4 rounded shadow text-center">
+                <div className="text-sm text-gray-500">Avg Order Value</div>
+                <div className="text-xl font-semibold">
+                  {metrics.avgOrderValue ?? '-'}
+                </div>
+              </div>
+              <div className="bg-white p-4 rounded shadow text-center">
+                <div className="text-sm text-gray-500">Conversion Rate</div>
+                <div className="text-xl font-semibold">
+                  {metrics.conversionRate ?? '-'}
+                </div>
+              </div>
+            </div>
 
-        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-4">
-          <div className="bg-white p-4 rounded shadow text-center">
-            <div className="text-sm text-gray-500">Total Sales</div>
-            <div className="text-xl font-semibold">
-              {metrics.salesTotal ?? '-'}
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+              <div className="bg-white p-4 rounded shadow">
+                <div className="mb-2 font-semibold">Sales Over Time</div>
+                <ResponsiveContainer width="100%" height={250}>
+                  <LineChart data={metrics.salesByDay || []}>
+                    <CartesianGrid strokeDasharray="3 3" />
+                    <XAxis dataKey="date" />
+                    <YAxis />
+                    <Tooltip />
+                    <Line type="monotone" dataKey="sales" stroke="#8884d8" />
+                  </LineChart>
+                </ResponsiveContainer>
+              </div>
+              <div className="bg-white p-4 rounded shadow">
+                <div className="mb-2 font-semibold">Sessions vs. Bounce Rate</div>
+                <ResponsiveContainer width="100%" height={250}>
+                  <LineChart data={combinedSessions}>
+                    <CartesianGrid strokeDasharray="3 3" />
+                    <XAxis dataKey="date" />
+                    <YAxis yAxisId="left" />
+                    <YAxis yAxisId="right" orientation="right" />
+                    <Tooltip />
+                    <Legend />
+                    <Line yAxisId="left" type="monotone" dataKey="sessions" stroke="#82ca9d" />
+                    <Line yAxisId="right" type="monotone" dataKey="bounce" stroke="#ff7300" />
+                  </LineChart>
+                </ResponsiveContainer>
+              </div>
             </div>
-          </div>
-          <div className="bg-white p-4 rounded shadow text-center">
-            <div className="text-sm text-gray-500">Total Sessions</div>
-            <div className="text-xl font-semibold">
-              {metrics.sessionsTotal ?? '-'}
-            </div>
-          </div>
-          <div className="bg-white p-4 rounded shadow text-center">
-            <div className="text-sm text-gray-500">Bounce Rate</div>
-            <div className="text-xl font-semibold">
-              {metrics.bounceRate ?? '-'}
-            </div>
-          </div>
-          <div className="bg-white p-4 rounded shadow text-center">
-            <div className="text-sm text-gray-500">Avg Order Value</div>
-            <div className="text-xl font-semibold">
-              {metrics.avgOrderValue ?? '-'}
-            </div>
-          </div>
-          <div className="bg-white p-4 rounded shadow text-center">
-            <div className="text-sm text-gray-500">Conversion Rate</div>
-            <div className="text-xl font-semibold">
-              {metrics.conversionRate ?? '-'}
-            </div>
-          </div>
-        </div>
-
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-          <div className="bg-white p-4 rounded shadow">
-            <div className="mb-2 font-semibold">Sales Over Time</div>
-            <ResponsiveContainer width="100%" height={250}>
-              <LineChart data={metrics.salesByDay || []}>
-                <CartesianGrid strokeDasharray="3 3" />
-                <XAxis dataKey="date" />
-                <YAxis />
-                <Tooltip />
-                <Line type="monotone" dataKey="sales" stroke="#8884d8" />
-              </LineChart>
-            </ResponsiveContainer>
-          </div>
-          <div className="bg-white p-4 rounded shadow">
-            <div className="mb-2 font-semibold">Sessions vs. Bounce Rate</div>
-            <ResponsiveContainer width="100%" height={250}>
-              <LineChart data={combinedSessions}>
-                <CartesianGrid strokeDasharray="3 3" />
-                <XAxis dataKey="date" />
-                <YAxis yAxisId="left" />
-                <YAxis yAxisId="right" orientation="right" />
-                <Tooltip />
-                <Legend />
-                <Line yAxisId="left" type="monotone" dataKey="sessions" stroke="#82ca9d" />
-                <Line yAxisId="right" type="monotone" dataKey="bounce" stroke="#ff7300" />
-              </LineChart>
-            </ResponsiveContainer>
-          </div>
-        </div>
+          </>
+        )}
       </div>
     </AdminLayout>
   );

--- a/client/src/admin/pages/StoresList.jsx
+++ b/client/src/admin/pages/StoresList.jsx
@@ -1,29 +1,18 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { Link } from 'react-router-dom';
-import axios from 'axios';
 import AdminLayout from '../layout/AdminLayout';
+import Loading from '../../components/Loading';
+import useApi from '../../hooks/useApi';
+import { getStores } from '../../services/api';
 
 export default function StoresList() {
-  const [stores, setStores] = useState([]);
-  const [total, setTotal] = useState(0);
   const [offset, setOffset] = useState(0);
   const [limit, setLimit] = useState(10);
   const [search, setSearch] = useState('');
 
-  useEffect(() => {
-    axios
-      .get('/api/admin/stores', {
-        params: { offset, limit, search },
-      })
-      .then((res) => {
-        setStores(res.data.stores || []);
-        setTotal(res.data.total || 0);
-      })
-      .catch(() => {
-        setStores([]);
-        setTotal(0);
-      });
-  }, [offset, limit, search]);
+  const { data, loading, error } = useApi(getStores, offset, limit, search);
+  const stores = data?.stores || [];
+  const total = data?.total || 0;
 
   const handleSearchChange = (e) => {
     setSearch(e.target.value);
@@ -52,25 +41,32 @@ export default function StoresList() {
           placeholder="Search stores..."
           className="w-full border rounded p-2"
         />
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-          {stores.map((store) => (
-            <div key={store.id} className="bg-white rounded shadow p-4 space-y-2">
-              <Link to={`/store/${store.handle}`} className="text-lg font-semibold text-blue-600">
-                {store.name}
-              </Link>
-              <div className="text-sm text-gray-600">@{store.handle}</div>
-              <div className="text-sm">{store.ownerEmail}</div>
-              <div className="flex gap-2">
-                <span className="bg-green-100 text-green-800 text-xs px-2 py-1 rounded">
-                  Sales: {store.sales7d}
-                </span>
-                <span className="bg-blue-100 text-blue-800 text-xs px-2 py-1 rounded">
-                  Sessions: {store.sessions7d}
-                </span>
+        {error && (
+          <p className="text-red-500 text-center">{error.message || 'Failed to load stores'}</p>
+        )}
+        {loading ? (
+          <Loading />
+        ) : (
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            {stores.map((store) => (
+              <div key={store.id} className="bg-white rounded shadow p-4 space-y-2">
+                <Link to={`/store/${store.handle}`} className="text-lg font-semibold text-blue-600">
+                  {store.name}
+                </Link>
+                <div className="text-sm text-gray-600">@{store.handle}</div>
+                <div className="text-sm">{store.ownerEmail}</div>
+                <div className="flex gap-2">
+                  <span className="bg-green-100 text-green-800 text-xs px-2 py-1 rounded">
+                    Sales: {store.sales7d}
+                  </span>
+                  <span className="bg-blue-100 text-blue-800 text-xs px-2 py-1 rounded">
+                    Sessions: {store.sessions7d}
+                  </span>
+                </div>
               </div>
-            </div>
-          ))}
-        </div>
+            ))}
+          </div>
+        )}
         <div className="flex justify-between">
           <button
             onClick={back}

--- a/client/src/admin/pages/ThemeAdmin.jsx
+++ b/client/src/admin/pages/ThemeAdmin.jsx
@@ -1,11 +1,49 @@
+import { useState } from 'react';
 import AdminLayout from '../layout/AdminLayout';
+import Loading from '../../components/Loading';
+import useApi from '../../hooks/useApi';
+import { getThemes } from '../../services/api';
 
 export default function ThemeAdmin() {
+  const [offset, setOffset] = useState(0);
+  const limit = 10;
+  const { data, loading, error } = useApi(getThemes, offset, limit);
+  const themes = data?.themes || [];
+
+  const next = () => setOffset(offset + limit);
+  const back = () => setOffset(Math.max(0, offset - limit));
+
   return (
     <AdminLayout>
       <div className="space-y-4">
         <h1 className="text-xl">Theme Marketplace</h1>
-        {/* TODO: list and manage themes */}
+        {error && (
+          <p className="text-red-500 text-center">{error.message || 'Failed to load themes'}</p>
+        )}
+        {loading ? (
+          <Loading />
+        ) : (
+          <ul className="space-y-2">
+            {themes.map((theme) => (
+              <li key={theme._id}>{theme.name}</li>
+            ))}
+          </ul>
+        )}
+        <div className="flex justify-between">
+          <button
+            onClick={back}
+            disabled={offset === 0}
+            className="px-4 py-2 bg-gray-200 rounded disabled:opacity-50"
+          >
+            Back
+          </button>
+          <button
+            onClick={next}
+            className="px-4 py-2 bg-gray-200 rounded"
+          >
+            Next
+          </button>
+        </div>
       </div>
     </AdminLayout>
   );

--- a/client/src/admin/pages/Users.jsx
+++ b/client/src/admin/pages/Users.jsx
@@ -2,15 +2,72 @@ import { useState } from 'react';
 import AdminLayout from '../layout/AdminLayout';
 import UserTable from '../components/UserTable';
 import RoleToggleModal from '../components/RoleToggleModal';
+import Loading from '../../components/Loading';
+import useApi from '../../hooks/useApi';
+import { getUsers } from '../../services/api';
 
 export default function Users() {
   const [activeUser, setActiveUser] = useState(null);
+  const [offset, setOffset] = useState(0);
+  const [limit, setLimit] = useState(10);
+  const [search, setSearch] = useState('');
+
+  const { data, loading, error } = useApi(getUsers, offset, limit, search);
+  const users = data?.users || [];
+  const total = data?.total || 0;
+
+  const handleSearchChange = (e) => {
+    setSearch(e.target.value);
+    setOffset(0);
+  };
+
+  const next = () => {
+    if (offset + limit < total) {
+      setOffset(offset + limit);
+    }
+  };
+
+  const back = () => {
+    if (offset - limit >= 0) {
+      setOffset(offset - limit);
+    }
+  };
 
   return (
     <AdminLayout>
       <div className="space-y-4">
         <h1 className="text-xl">User Management</h1>
-        <UserTable onEdit={setActiveUser} />
+        <input
+          type="text"
+          value={search}
+          onChange={handleSearchChange}
+          placeholder="Search users..."
+          className="w-full border rounded p-2"
+        />
+        {error && (
+          <p className="text-red-500 text-center">{error.message || 'Failed to load users'}</p>
+        )}
+        {loading ? (
+          <Loading />
+        ) : (
+          <UserTable users={users} onEdit={setActiveUser} />
+        )}
+        <div className="flex justify-between">
+          <button
+            onClick={back}
+            disabled={offset === 0}
+            className="px-4 py-2 bg-gray-200 rounded disabled:opacity-50"
+          >
+            Back
+          </button>
+          <button
+            onClick={next}
+            disabled={offset + limit >= total}
+            className="px-4 py-2 bg-gray-200 rounded disabled:opacity-50"
+          >
+            Next
+          </button>
+        </div>
         {activeUser && (
           <RoleToggleModal user={activeUser} onClose={() => setActiveUser(null)} />
         )}

--- a/client/src/admin/pages/__tests__/StoreDetails.test.jsx
+++ b/client/src/admin/pages/__tests__/StoreDetails.test.jsx
@@ -1,9 +1,11 @@
 import { render } from '@testing-library/react';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
-import axios from 'axios';
 import StoreDetails from '../StoreDetails.jsx';
+import { getStoreMetrics } from '../../../services/api.js';
 
-jest.mock('axios');
+jest.mock('../../../services/api.js', () => ({
+  getStoreMetrics: jest.fn(),
+}));
 jest.mock('recharts', () => ({
   LineChart: () => null,
   Line: () => null,
@@ -17,7 +19,7 @@ jest.mock('recharts', () => ({
 
 describe('StoreDetails Page', () => {
   it('renders without crashing', () => {
-    axios.get.mockResolvedValue({ data: {} });
+    getStoreMetrics.mockResolvedValue({ data: {} });
     render(
       <MemoryRouter initialEntries={['/admin/stores/1']}>
         <Routes>

--- a/client/src/admin/pages/__tests__/StoresList.test.jsx
+++ b/client/src/admin/pages/__tests__/StoresList.test.jsx
@@ -1,13 +1,15 @@
 import { render } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import axios from 'axios';
 import StoresList from '../StoresList.jsx';
+import { getStores } from '../../../services/api.js';
 
-jest.mock('axios');
+jest.mock('../../../services/api.js', () => ({
+  getStores: jest.fn(),
+}));
 
 describe('StoresList Page', () => {
   it('renders without crashing', () => {
-    axios.get.mockResolvedValue({ data: { stores: [], total: 0 } });
+    getStores.mockResolvedValue({ data: { stores: [], total: 0 } });
     render(
       <MemoryRouter>
         <StoresList />

--- a/client/src/admin/pages/__tests__/ThemeAdmin.test.jsx
+++ b/client/src/admin/pages/__tests__/ThemeAdmin.test.jsx
@@ -1,9 +1,15 @@
 import { render } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import ThemeAdmin from '../ThemeAdmin.jsx';
+import { getThemes } from '../../../services/api.js';
+
+jest.mock('../../../services/api.js', () => ({
+  getThemes: jest.fn(),
+}));
 
 describe('ThemeAdmin Page', () => {
   it('renders without crashing', () => {
+    getThemes.mockResolvedValue({ data: { themes: [], total: 0 } });
     render(
       <MemoryRouter>
         <ThemeAdmin />

--- a/client/src/admin/pages/__tests__/Users.test.jsx
+++ b/client/src/admin/pages/__tests__/Users.test.jsx
@@ -1,9 +1,15 @@
 import { render } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import Users from '../Users.jsx';
+import { getUsers } from '../../../services/api.js';
+
+jest.mock('../../../services/api.js', () => ({
+  getUsers: jest.fn(),
+}));
 
 describe('Users Page', () => {
   it('renders without crashing', () => {
+    getUsers.mockResolvedValue({ data: { users: [], total: 0 } });
     render(
       <MemoryRouter>
         <Users />

--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -11,3 +11,27 @@ export function previewTheme(id, config = {}) {
 export function selectTheme(id, config = {}) {
   return axios.post('/api/store/theme', { themeId: id }, { withCredentials: true, ...config });
 }
+
+export function getStores(offset, limit, search, config = {}) {
+  return axios.get('/api/admin/stores', {
+    params: { offset, limit, search },
+    withCredentials: true,
+    ...config
+  });
+}
+
+export function getStoreMetrics(storeId, from, to, config = {}) {
+  return axios.get(`/api/admin/stores/${storeId}/metrics`, {
+    params: { from, to },
+    withCredentials: true,
+    ...config
+  });
+}
+
+export function getUsers(offset, limit, search, config = {}) {
+  return axios.get('/api/admin/users', {
+    params: { offset, limit, search },
+    withCredentials: true,
+    ...config
+  });
+}


### PR DESCRIPTION
## Summary
- use reusable `useApi` hook across admin pages
- show loading spinners and error messages for admin data tables
- add admin API helpers and adjust tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894d4cd3924832e83e6572ab04c5006