### PR TITLE
Configure coverage to include source files

### DIFF
--- a/client/jest.config.cjs
+++ b/client/jest.config.cjs
@@ -7,10 +7,8 @@ module.exports = {
   moduleNameMapper: {
     '^recharts$': '<rootDir>/src/__mocks__/recharts.js',
   },
-  collectCoverageFrom: [
-    'src/admin/pages/__tests__/**/*.jsx',
-    'src/components/__tests__/**/*.jsx',
-  ],
+  collectCoverageFrom: ['src/**/*.{js,jsx}'],
+  coveragePathIgnorePatterns: ['/node_modules/', '/__tests__/'],
   coverageThreshold: {
     global: {
       branches: 80,

--- a/moohaar-backend/jest.config.js
+++ b/moohaar-backend/jest.config.js
@@ -1,7 +1,7 @@
 export default {
   testEnvironment: 'node',
-  coveragePathIgnorePatterns: ['/node_modules/', 'src/server.js'],
-  collectCoverageFrom: ['src/__tests__/**/*.js', 'src/controllers/__tests__/**/*.js'],
+  coveragePathIgnorePatterns: ['/node_modules/', 'src/server.js', '/__tests__/'],
+  collectCoverageFrom: ['src/**/*.{js,jsx}'],
   coverageThreshold: {
     global: {
       branches: 80,


### PR DESCRIPTION
## Summary
- collect coverage from source files in client and backend
- ignore test directories when generating coverage

## Testing
- `cd client && npm test -- --coverage`
- `cd moohaar-backend && npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_6894d4d36408832e962848263421204a