### PR TITLE
Implement admin database operations and tests

### DIFF
--- a/moohaar-backend/src/__tests__/admin.settings.test.js
+++ b/moohaar-backend/src/__tests__/admin.settings.test.js
@@ -1,6 +1,60 @@
-import adminController from '../controllers/admin.controller.js';
+import request from 'supertest';
+import jwt from 'jsonwebtoken';
+import { jest } from '@jest/globals';
+
+let settingsData = {};
+
+const findOne = jest.fn().mockImplementation(() => {
+  if (Object.keys(settingsData).length === 0) return Promise.resolve(null);
+  return Promise.resolve(settingsData);
+});
+const findOneAndUpdate = jest.fn().mockImplementation((_query, update) => {
+  settingsData = { ...settingsData, ...update };
+  return Promise.resolve(settingsData);
+});
+
+jest.unstable_mockModule('../models/setting.model.js', () => ({
+  default: { findOne, findOneAndUpdate },
+}));
+
+jest.unstable_mockModule('../models/store.model.js', () => ({
+  default: { findOne: jest.fn().mockResolvedValue(null) },
+}));
+
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'testsecret';
+const token = jwt.sign({ userId: '1', role: 'admin' }, process.env.JWT_SECRET);
+
+const { app } = await import('../server.js');
+const agent = request.agent(app);
+
+const getCsrf = async () => {
+  const res = await agent.get('/api/csrf-token');
+  return res.body.csrfToken;
+};
 
 describe('Admin Settings Controller', () => {
-  test.todo('should get settings');
-  test.todo('should update settings');
+  test('should get settings', async () => {
+    settingsData = {};
+    const res = await request(app)
+      .get('/api/admin/settings')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    expect(res.body.settings).toEqual({});
+    expect(findOne).toHaveBeenCalled();
+  });
+
+  test('should update settings', async () => {
+    settingsData = {};
+    const csrf = await getCsrf();
+    const res = await agent
+      .put('/api/admin/settings')
+      .set('X-CSRF-Token', csrf)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ maintenanceMode: true });
+    expect(res.status).toBe(200);
+    expect(res.body.settings.maintenanceMode).toBe(true);
+    expect(findOneAndUpdate).toHaveBeenCalled();
+  });
 });
+

--- a/moohaar-backend/src/__tests__/admin.themes.test.js
+++ b/moohaar-backend/src/__tests__/admin.themes.test.js
@@ -1,8 +1,121 @@
-import adminController from '../controllers/admin.controller.js';
+import request from 'supertest';
+import jwt from 'jsonwebtoken';
+import { jest } from '@jest/globals';
+
+const themes = [];
+
+const find = jest.fn().mockImplementation(() => Promise.resolve(themes));
+const findByIdAndUpdate = jest.fn().mockImplementation((id, update) => {
+  const theme = themes.find((t) => t._id === id);
+  if (!theme) return null;
+  if (update.$set && update.$set['metadata.status']) {
+    theme.metadata.status = update.$set['metadata.status'];
+  } else {
+    Object.assign(theme, update);
+  }
+  return theme;
+});
+
+jest.unstable_mockModule('../models/theme.model.js', () => ({
+  default: { find, findByIdAndUpdate },
+}));
+
+jest.unstable_mockModule('../models/store.model.js', () => ({
+  default: { findOne: jest.fn().mockResolvedValue(null) },
+}));
+
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'testsecret';
+const token = jwt.sign({ userId: '1', role: 'admin' }, process.env.JWT_SECRET);
+
+const { app } = await import('../server.js');
+const agent = request.agent(app);
+
+const getCsrf = async () => {
+  const res = await agent.get('/api/csrf-token');
+  return res.body.csrfToken;
+};
 
 describe('Admin Themes Controller', () => {
-  test.todo('should list themes');
-  test.todo('should approve a theme');
-  test.todo('should update a theme');
-  test.todo('should disable a theme');
+  test('should list themes', async () => {
+    themes.length = 0;
+    themes.push({
+      _id: '1',
+      name: 'Theme1',
+      version: '1.0',
+      description: 'd',
+      previewImage: 'img',
+      paths: {},
+      metadata: { status: 'pending' },
+    });
+    const res = await request(app)
+      .get('/api/admin/themes')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    expect(res.body.themes).toHaveLength(1);
+    expect(find).toHaveBeenCalled();
+  });
+
+  test('should approve a theme', async () => {
+    themes.length = 0;
+    const theme = {
+      _id: '2',
+      name: 'Theme2',
+      version: '1.0',
+      description: 'd',
+      previewImage: 'img',
+      paths: {},
+      metadata: { status: 'pending' },
+    };
+    themes.push(theme);
+    const csrf = await getCsrf();
+    const res = await agent
+      .post(`/api/admin/themes/${theme._id}/approve`)
+      .set('X-CSRF-Token', csrf)
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    expect(res.body.metadata.status).toBe('approved');
+  });
+
+  test('should update a theme', async () => {
+    themes.length = 0;
+    const theme = {
+      _id: '3',
+      name: 'Theme3',
+      version: '1.0',
+      description: 'old',
+      previewImage: 'img',
+      paths: {},
+      metadata: { status: 'approved' },
+    };
+    themes.push(theme);
+    const csrf = await getCsrf();
+    const res = await agent
+      .put(`/api/admin/themes/${theme._id}`)
+      .set('X-CSRF-Token', csrf)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ description: 'new desc' });
+    expect(res.status).toBe(200);
+    expect(res.body.description).toBe('new desc');
+  });
+
+  test('should disable a theme', async () => {
+    themes.length = 0;
+    const theme = {
+      _id: '4',
+      name: 'Theme4',
+      version: '1.0',
+      description: 'd',
+      previewImage: 'img',
+      paths: {},
+      metadata: { status: 'approved' },
+    };
+    themes.push(theme);
+    const res = await request(app)
+      .patch(`/api/admin/themes/${theme._id}/disable`)
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    expect(res.body.metadata.status).toBe('disabled');
+  });
 });
+

--- a/moohaar-backend/src/__tests__/admin.users.test.js
+++ b/moohaar-backend/src/__tests__/admin.users.test.js
@@ -1,6 +1,60 @@
-import adminController from '../controllers/admin.controller.js';
+import request from 'supertest';
+import jwt from 'jsonwebtoken';
+import { jest } from '@jest/globals';
+
+const users = [
+  { _id: '1', email: 'admin@example.com', passwordHash: 'hash', role: 'admin' },
+  { _id: '2', email: 'user@example.com', passwordHash: 'hash', role: 'merchant' },
+];
+
+const find = jest.fn().mockReturnValue({
+  skip: () => ({
+    limit: () => Promise.resolve(users),
+  }),
+});
+const countDocuments = jest.fn().mockResolvedValue(users.length);
+const findByIdAndUpdate = jest
+  .fn()
+  .mockImplementation((id, update) => {
+    const user = users.find((u) => u._id === id);
+    if (!user) return null;
+    Object.assign(user, update);
+    return user;
+  });
+
+jest.unstable_mockModule('../models/user.model.js', () => ({
+  default: { find, countDocuments, findByIdAndUpdate },
+}));
+
+jest.unstable_mockModule('../models/store.model.js', () => ({
+  default: { findOne: jest.fn().mockResolvedValue(null) },
+}));
+
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'testsecret';
+const token = jwt.sign({ userId: '1', role: 'admin' }, process.env.JWT_SECRET);
+
+const { app } = await import('../server.js');
 
 describe('Admin Users Controller', () => {
-  test.todo('should list users');
-  test.todo('should update a user');
+  test('should list users', async () => {
+    const res = await request(app)
+      .get('/api/admin/users')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    expect(res.body.total).toBe(2);
+    expect(res.body.users).toHaveLength(2);
+    expect(find).toHaveBeenCalled();
+  });
+
+  test('should update a user', async () => {
+    const res = await request(app)
+      .patch('/api/admin/users/2')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ role: 'admin' });
+    expect(res.status).toBe(200);
+    expect(res.body.role).toBe('admin');
+    expect(findByIdAndUpdate).toHaveBeenCalledWith('2', { role: 'admin' }, { new: true });
+  });
 });
+

--- a/moohaar-backend/src/controllers/admin.controller.js
+++ b/moohaar-backend/src/controllers/admin.controller.js
@@ -1,29 +1,127 @@
-export const getDashboard = (_req, res) =>
-  res.json({ message: 'admin dashboard placeholder' });
+import User from '../models/user.model.js';
+import Theme from '../models/theme.model.js';
+import Setting from '../models/setting.model.js';
 
-export const listUsers = (_req, res) =>
-  res.json({ users: [], total: 0 });
+export const getDashboard = async (_req, res, next) => {
+  try {
+    const [users, themes] = await Promise.all([
+      User.countDocuments(),
+      Theme.countDocuments(),
+    ]);
+    return res.json({ users, themes });
+  } catch (err) {
+    return next(err);
+  }
+};
 
-export const updateUser = (_req, res) =>
-  res.json({ message: 'update user placeholder' });
+export const listUsers = async (req, res, next) => {
+  try {
+    let { offset = 0, limit = 10 } = req.query;
+    offset = parseInt(offset, 10);
+    limit = parseInt(limit, 10);
 
-export const listThemes = (_req, res) =>
-  res.json({ themes: [] });
+    const [users, total] = await Promise.all([
+      User.find().skip(offset).limit(limit),
+      User.countDocuments(),
+    ]);
 
-export const approveTheme = (_req, res) =>
-  res.json({ message: 'approve theme placeholder' });
+    return res.json({ users, total, offset, limit });
+  } catch (err) {
+    return next(err);
+  }
+};
 
-export const updateTheme = (_req, res) =>
-  res.json({ message: 'update theme placeholder' });
+export const updateUser = async (req, res, next) => {
+  try {
+    const { userId } = req.params;
+    const updates = req.body;
+    const user = await User.findByIdAndUpdate(userId, updates, { new: true });
+    if (!user) {
+      return res.status(404).json({ message: 'User not found' });
+    }
+    return res.json(user);
+  } catch (err) {
+    return next(err);
+  }
+};
 
-export const disableTheme = (_req, res) =>
-  res.json({ message: 'disable theme placeholder' });
+export const listThemes = async (_req, res, next) => {
+  try {
+    const themes = await Theme.find();
+    return res.json({ themes });
+  } catch (err) {
+    return next(err);
+  }
+};
 
-export const getSettings = (_req, res) =>
-  res.json({ settings: {} });
+export const approveTheme = async (req, res, next) => {
+  try {
+    const { themeId } = req.params;
+    const theme = await Theme.findByIdAndUpdate(
+      themeId,
+      { $set: { 'metadata.status': 'approved' } },
+      { new: true }
+    );
+    if (!theme) {
+      return res.status(404).json({ message: 'Theme not found' });
+    }
+    return res.json(theme);
+  } catch (err) {
+    return next(err);
+  }
+};
 
-export const updateSettings = (_req, res) =>
-  res.json({ message: 'update settings placeholder' });
+export const updateTheme = async (req, res, next) => {
+  try {
+    const { themeId } = req.params;
+    const updates = req.body;
+    const theme = await Theme.findByIdAndUpdate(themeId, updates, { new: true });
+    if (!theme) {
+      return res.status(404).json({ message: 'Theme not found' });
+    }
+    return res.json(theme);
+  } catch (err) {
+    return next(err);
+  }
+};
+
+export const disableTheme = async (req, res, next) => {
+  try {
+    const { themeId } = req.params;
+    const theme = await Theme.findByIdAndUpdate(
+      themeId,
+      { $set: { 'metadata.status': 'disabled' } },
+      { new: true }
+    );
+    if (!theme) {
+      return res.status(404).json({ message: 'Theme not found' });
+    }
+    return res.json(theme);
+  } catch (err) {
+    return next(err);
+  }
+};
+
+export const getSettings = async (_req, res, next) => {
+  try {
+    const settings = await Setting.findOne();
+    return res.json({ settings: settings || {} });
+  } catch (err) {
+    return next(err);
+  }
+};
+
+export const updateSettings = async (req, res, next) => {
+  try {
+    const settings = await Setting.findOneAndUpdate({}, req.body, {
+      new: true,
+      upsert: true,
+    });
+    return res.json({ settings });
+  } catch (err) {
+    return next(err);
+  }
+};
 
 export default {
   getDashboard,

--- a/moohaar-backend/src/models/setting.model.js
+++ b/moohaar-backend/src/models/setting.model.js
@@ -1,0 +1,5 @@
+import mongoose from 'mongoose';
+
+const SettingSchema = new mongoose.Schema({}, { strict: false });
+
+export default mongoose.model('Setting', SettingSchema);

--- a/moohaar-backend/src/routes/admin.routes.js
+++ b/moohaar-backend/src/routes/admin.routes.js
@@ -10,8 +10,12 @@ import {
   getSettings,
   updateSettings,
 } from '../controllers/admin.controller';
+import auth from '../middleware/auth';
+import authorizeAdmin from '../middleware/authorizeAdmin';
 
 const router = Router();
+
+router.use(auth, authorizeAdmin);
 
 router.get('/dashboard', getDashboard);
 


### PR DESCRIPTION
## Summary
- Implement database-backed admin controller actions for users, themes and settings
- Secure admin routes with auth and admin authorization
- Add integration tests for user, theme and settings admin endpoints

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894d4c629b0832e81d7124e662c10ed