### PR TITLE
feat: add admin login page and routing

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -3,6 +3,7 @@ import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-d
 import Home from './pages/Home';
 import Login from './pages/Login';
 import Signup from './pages/Signup';
+import AdminLogin from './admin/pages/Login';
 // Lazily load heavy pages for route-based code splitting
 const Dashboard = React.lazy(() => import('./pages/Dashboard'));
 const AdminDashboard = React.lazy(() => import('./admin/pages/Dashboard'));
@@ -51,12 +52,15 @@ export default function App() {
           <Route path="/analytics" element={<PrivateRoute><Analytics /></PrivateRoute>} />
           <Route path="/create-store" element={<PrivateRoute><CreateStore /></PrivateRoute>} />
           <Route path="/themes" element={<ThemeStore />} />
-          <Route path="/admin" element={<AdminRoute><AdminDashboard /></AdminRoute>} />
-          <Route path="/admin/stores" element={<AdminRoute><StoresList /></AdminRoute>} />
-          <Route path="/admin/stores/:storeId" element={<AdminRoute><StoreDetails /></AdminRoute>} />
-          <Route path="/admin/users" element={<AdminRoute><Users /></AdminRoute>} />
-          <Route path="/admin/themes" element={<AdminRoute><ThemeAdmin /></AdminRoute>} />
-          <Route path="/admin/settings" element={<AdminRoute><Settings /></AdminRoute>} />
+          <Route path="/admin/login" element={<AdminLogin />} />
+          <Route path="/admin" element={<AdminRoute />}> 
+            <Route index element={<AdminDashboard />} />
+            <Route path="stores" element={<StoresList />} />
+            <Route path="stores/:storeId" element={<StoreDetails />} />
+            <Route path="users" element={<Users />} />
+            <Route path="themes" element={<ThemeAdmin />} />
+            <Route path="settings" element={<Settings />} />
+          </Route>
           <Route path="/upload-theme" element={<PrivateRoute><ThemeUpload /></PrivateRoute>} />
           <Route path="/forgot-password" element={<ForgotPassword />} />
           <Route path="/reset-password/:token" element={<ResetPassword />} />

--- a/client/src/admin/pages/Login.jsx
+++ b/client/src/admin/pages/Login.jsx
@@ -1,0 +1,61 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { login } from '../../services/auth.service';
+
+export default function Login() {
+  const navigate = useNavigate();
+  const [form, setForm] = useState({ email: '', password: '' });
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const handleChange = e => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = async e => {
+    e.preventDefault();
+    setError('');
+    setLoading(true);
+    try {
+      await login(form);
+      navigate('/admin/stores');
+    } catch (err) {
+      setError(err.response?.data?.msg || 'Login failed');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 p-4">
+      <form onSubmit={handleSubmit} className="w-full max-w-sm space-y-4">
+        {error && <div className="text-red-600 text-center">{error}</div>}
+        <input
+          type="email"
+          name="email"
+          value={form.email}
+          onChange={handleChange}
+          placeholder="Email"
+          required
+          className="w-full p-2 border rounded"
+        />
+        <input
+          type="password"
+          name="password"
+          value={form.password}
+          onChange={handleChange}
+          placeholder="Password"
+          required
+          className="w-full p-2 border rounded"
+        />
+        <button
+          type="submit"
+          disabled={loading}
+          className="w-full py-2 bg-indigo-600 text-white rounded disabled:opacity-50"
+        >
+          {loading ? 'Logging in...' : 'Login'}
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/client/src/components/AdminRoute.jsx
+++ b/client/src/components/AdminRoute.jsx
@@ -1,3 +1,30 @@
-export default function AdminRoute({ children }) {
-  return children;
+import { Navigate, Outlet, useLocation } from 'react-router-dom';
+
+function getCookie(name) {
+  return document.cookie
+    .split('; ')
+    .find(row => row.startsWith(`${name}=`))
+    ?.split('=')[1];
+}
+
+function decodeJwt(token) {
+  try {
+    return JSON.parse(atob(token.split('.')[1]));
+  } catch {
+    return null;
+  }
+}
+
+export default function AdminRoute() {
+  const location = useLocation();
+  const token = getCookie('accessToken');
+  const payload = token ? decodeJwt(token) : null;
+  const isValid = payload && (!payload.exp || payload.exp * 1000 > Date.now());
+  const isAdmin = payload?.user?.role === 'admin' || payload?.role === 'admin';
+
+  if (!isValid || !isAdmin) {
+    return <Navigate to="/admin/login" state={{ from: location }} replace />;
+  }
+
+  return <Outlet />;
 }


### PR DESCRIPTION
## Summary
- add mobile-first admin login page wired to auth service
- guard admin routes with role-aware JWT check
- centralize admin route registration with login redirect

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689571cb11b4832ea98ec8caf740e086