### PR TITLE
feat: add initial admin registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This repository contains a React frontend (Vite) and an Express backend with MongoDB.
 
+## Admin Registration
+
+The first user to visit `/admin/register` will become the initial admin. All later registrations create merchant accounts.
+
 ## Available Scripts
 
 ### Client

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -4,6 +4,7 @@ import Home from './pages/Home';
 import Login from './pages/Login';
 import Signup from './pages/Signup';
 import AdminLogin from './admin/pages/Login';
+import AdminRegister from './admin/pages/Register';
 // Lazily load heavy pages for route-based code splitting
 const Dashboard = React.lazy(() => import('./pages/Dashboard'));
 const AdminDashboard = React.lazy(() => import('./admin/pages/Dashboard'));
@@ -53,7 +54,8 @@ export default function App() {
           <Route path="/create-store" element={<PrivateRoute><CreateStore /></PrivateRoute>} />
           <Route path="/themes" element={<ThemeStore />} />
           <Route path="/admin/login" element={<AdminLogin />} />
-          <Route path="/admin" element={<AdminRoute />}> 
+          <Route path="/admin/register" element={<AdminRegister />} />
+          <Route path="/admin" element={<AdminRoute />}>
             <Route index element={<AdminDashboard />} />
             <Route path="stores" element={<StoresList />} />
             <Route path="stores/:storeId" element={<StoreDetails />} />

--- a/client/src/admin/pages/Dashboard.jsx
+++ b/client/src/admin/pages/Dashboard.jsx
@@ -1,6 +1,34 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import AdminLayout from '../layout/AdminLayout';
 
+function getCookie(name) {
+  return document.cookie
+    .split('; ')
+    .find(row => row.startsWith(`${name}=`))
+    ?.split('=')[1];
+}
+
+function decodeJwt(token) {
+  try {
+    return JSON.parse(atob(token.split('.')[1]));
+  } catch {
+    return null;
+  }
+}
+
 export default function Dashboard() {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const token = getCookie('accessToken');
+    const payload = token ? decodeJwt(token) : null;
+    const isAdmin = payload?.user?.role === 'admin' || payload?.role === 'admin';
+    if (!isAdmin) {
+      navigate('/admin/login');
+    }
+  }, [navigate]);
+
   return (
     <AdminLayout>
       <div className="text-xl">Admin Dashboard</div>

--- a/client/src/admin/pages/Register.jsx
+++ b/client/src/admin/pages/Register.jsx
@@ -1,8 +1,8 @@
 import { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import { login } from '../../services/auth.service';
+import axios from 'axios';
 
-export default function Login() {
+export default function Register() {
   const navigate = useNavigate();
   const [form, setForm] = useState({ email: '', password: '' });
   const [error, setError] = useState('');
@@ -17,10 +17,10 @@ export default function Login() {
     setError('');
     setLoading(true);
     try {
-      await login(form);
-      navigate('/admin/stores');
+      await axios.post('/api/auth/register', form, { withCredentials: true });
+      navigate('/admin/login');
     } catch (err) {
-      setError(err.response?.data?.msg || 'Login failed');
+      setError(err.response?.data?.message || 'Registration failed');
     } finally {
       setLoading(false);
     }
@@ -53,11 +53,11 @@ export default function Login() {
           disabled={loading}
           className="w-full py-2 bg-indigo-600 text-white rounded disabled:opacity-50"
         >
-          {loading ? 'Logging in...' : 'Login'}
+          {loading ? 'Registering...' : 'Register'}
         </button>
         <div className="text-center">
-          <Link to="/admin/register" className="text-sm text-indigo-600 hover:underline">
-            Register as admin
+          <Link to="/admin/login" className="text-sm text-indigo-600 hover:underline">
+            Back to login
           </Link>
         </div>
       </form>

--- a/moohaar-backend/src/controllers/auth.controller.js
+++ b/moohaar-backend/src/controllers/auth.controller.js
@@ -7,7 +7,7 @@ import { hashPassword, comparePassword } from '../utils/password.util';
 // POST /api/auth/register
 export const register = async (req, res, next) => {
   try {
-    const { email, password, role } = req.body;
+    const { email, password } = req.body;
     if (!email || !password) {
       return res.status(400).json({ message: 'email and password are required' });
     }
@@ -16,7 +16,12 @@ export const register = async (req, res, next) => {
       return res.status(409).json({ message: 'email already exists' });
     }
     const passwordHash = await hashPassword(password);
-    const user = await User.create({ email, passwordHash, role });
+    const userCount = await User.countDocuments();
+    const user = await User.create({
+      email,
+      passwordHash,
+      role: userCount === 0 ? 'admin' : 'merchant',
+    });
     return res.status(201).json({ id: user.id, email: user.email, role: user.role });
   } catch (err) {
     return next(err);


### PR DESCRIPTION
## Summary
- add public admin registration page and route
- seed first signup as admin and limit later signups to merchant
- document initial admin registration

## Testing
- `npm test` (backend)
- `npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68957e26a734832eaef5c42eb01c5a63