### PR TITLE
refactor: harden user registration logic

### DIFF
--- a/moohaar-backend/src/controllers/auth.controller.js
+++ b/moohaar-backend/src/controllers/auth.controller.js
@@ -5,7 +5,8 @@ import config from '../config/index';
 import { hashPassword, comparePassword } from '../utils/password.util';
 
 // POST /api/auth/register
-export const register = async (req, res, next) => {
+export const register = async (req, res) => {
+  console.log('Register body:', req.body);
   try {
     const { email, password } = req.body;
     if (!email || !password) {
@@ -17,14 +18,12 @@ export const register = async (req, res, next) => {
     }
     const passwordHash = await hashPassword(password);
     const userCount = await User.countDocuments();
-    const user = await User.create({
-      email,
-      passwordHash,
-      role: userCount === 0 ? 'admin' : 'merchant',
-    });
+    const role = req.body.role === 'admin' && userCount === 0 ? 'admin' : 'merchant';
+    const user = await User.create({ email, passwordHash, role });
     return res.status(201).json({ id: user.id, email: user.email, role: user.role });
   } catch (err) {
-    return next(err);
+    console.error(err);
+    return res.status(400).json({ error: err.message });
   }
 };
 

--- a/moohaar-backend/src/routes/auth.routes.js
+++ b/moohaar-backend/src/routes/auth.routes.js
@@ -3,9 +3,9 @@ import { register, login, logout, refresh } from '../controllers/auth.controller
 
 const router = Router();
 
-router.post('/register', register);
 router.post('/login', login);
 router.post('/logout', logout);
 router.post('/refresh', refresh);
 
+export { register };
 export default router;

--- a/moohaar-backend/src/server.js
+++ b/moohaar-backend/src/server.js
@@ -14,7 +14,7 @@ import Theme from './models/theme.model';
 import themeRoutes from './controllers/theme.controller';
 import storeRoutes from './routes/store.routes';
 import healthRoutes from './routes/health.routes';
-import authRoutes from './routes/auth.routes';
+import authRoutes, { register as registerRoute } from './routes/auth.routes';
 import adminRoutes from './routes/admin.routes';
 import PageView from './models/pageview.model';
 import auth from './middleware/auth';
@@ -226,6 +226,7 @@ app.use(async (req, res, next) => {
 });
 
 // API routes
+app.post('/api/auth/register', registerRoute);
 app.use('/api/auth', authRoutes);
 app.use('/api/admin', auth, authorizeAdmin, adminRoutes);
 app.use('/api/themes', themeRoutes);


### PR DESCRIPTION
## Summary
- add explicit logging and error responses to auth register handler
- default new users to merchant unless first admin user requested
- expose register endpoint separately so it's mounted before other auth routes

## Testing
- `npm test`
- `npm run lint` *(fails: import/no-named-as-default-member, import/extensions, lines-between-class-members, prefer-destructuring, no-console)*

------
https://chatgpt.com/codex/tasks/task_e_689588dfd118832ead08aaf51fe39f39