### PR TITLE
Fix admin auth flow

### DIFF
--- a/client/src/admin/pages/Login.jsx
+++ b/client/src/admin/pages/Login.jsx
@@ -17,10 +17,17 @@ export default function Login() {
     setError('');
     setLoading(true);
     try {
-      await login(form);
-      navigate('/admin/stores');
+      const res = await login(form);
+      const { user } = res.data || {};
+      if (user?.role === 'admin') {
+        navigate('/admin/stores');
+      } else {
+        setError('Unauthorized');
+      }
     } catch (err) {
-      setError(err.response?.data?.msg || 'Login failed');
+      setError(
+        err.response?.data?.error || err.response?.data?.message || 'Login failed',
+      );
     } finally {
       setLoading(false);
     }
@@ -29,7 +36,6 @@ export default function Login() {
   return (
     <div className="min-h-screen flex items-center justify-center bg-gray-50 p-4">
       <form onSubmit={handleSubmit} className="w-full max-w-sm space-y-4">
-        {error && <div className="text-red-600 text-center">{error}</div>}
         <input
           type="email"
           name="email"
@@ -55,12 +61,13 @@ export default function Login() {
         >
           {loading ? 'Logging in...' : 'Login'}
         </button>
-        <div className="text-center">
-          <Link to="/admin/register" className="text-sm text-indigo-600 hover:underline">
-            Register as admin
-          </Link>
-        </div>
       </form>
+      {error && <div className="text-red-600 text-center mt-2">{error}</div>}
+      <div className="text-center mt-2">
+        <Link to="/admin/register" className="text-sm text-indigo-600 hover:underline">
+          Register as admin
+        </Link>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- improve register logging and error handling; first user becomes admin and passwords hash with bcrypt
- return user role on login and redirect admin dashboard on frontend
- show login errors and block non-admin access; ensure register route mounted before auth middleware

## Testing
- `cd moohaar-backend && npm test`
- `cd client && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895a4d72e74832ea5b8cddee27e95d5