### PR TITLE
chore: relax eslint for scripts and tests

### DIFF
--- a/moohaar-backend/.eslintrc.json
+++ b/moohaar-backend/.eslintrc.json
@@ -7,12 +7,32 @@
   },
   "overrides": [
     {
-      "files": ["**/__tests__/**/*.js"],
-      "env": { "jest": true }
+      "files": ["scripts/**/*.js"],
+      "rules": {
+        "no-console": "off",
+        "no-restricted-syntax": "off",
+        "no-await-in-loop": "off",
+        "no-continue": "off",
+        "import/no-extraneous-dependencies": "off"
+      }
+    },
+    {
+      "files": ["src/**/*.test.js"],
+      "env": { "jest": true },
+      "rules": {
+        "no-console": "off",
+        "no-restricted-syntax": "off",
+        "no-await-in-loop": "off",
+        "no-continue": "off",
+        "import/no-extraneous-dependencies": "off",
+        "lines-between-class-members": "off",
+        "import/no-named-as-default-member": "off",
+        "prefer-destructuring": "off"
+      }
     }
   ],
   "rules": {
-    "import/prefer-default-export": "error"
+    "import/prefer-default-export": "error",
+    "import/extensions": "off"
   }
 }
-

--- a/moohaar-backend/package.json
+++ b/moohaar-backend/package.json
@@ -44,6 +44,7 @@
     "pm2": "^5.3.0",
     "jest": "^29.7.0",
     "supertest": "^6.3.4",
-    "mongodb-memory-server": "^8.16.1"
+    "mongodb-memory-server": "^8.16.1",
+    "@jest/globals": "^29.7.0"
   }
 }

--- a/moohaar-backend/scripts/seedAdmins.js
+++ b/moohaar-backend/scripts/seedAdmins.js
@@ -16,16 +16,18 @@ async function seedAdmins() {
 
   try {
     await mongoose.connect(MONGODB_URI);
-    for (const { email, password } of accounts) {
-      const existingUser = await User.findOne({ email });
-      if (existingUser) {
-        console.log(`Admin user already exists: ${email}`);
-        continue;
-      }
-      const passwordHash = await bcrypt.hash(password, 10);
-      await User.create({ email, passwordHash, role: 'admin' });
-      console.log(`Admin user created: ${email} / Password: ${password}`);
-    }
+    await Promise.all(
+      accounts.map(async ({ email, password }) => {
+        const existingUser = await User.findOne({ email });
+        if (existingUser) {
+          console.log(`Admin user already exists: ${email}`);
+          return;
+        }
+        const passwordHash = await bcrypt.hash(password, 10);
+        await User.create({ email, passwordHash, role: 'admin' });
+        console.log(`Admin user created: ${email} / Password: ${password}`);
+      })
+    );
   } catch (err) {
     console.error('Error seeding admin users:', err);
   } finally {

--- a/moohaar-backend/src/__tests__/admin.settings.test.js
+++ b/moohaar-backend/src/__tests__/admin.settings.test.js
@@ -1,18 +1,18 @@
 import { jest } from '@jest/globals';
-import adminController from '../controllers/admin.controller.js';
+import { getSettings, updateSettings } from '../controllers/admin.controller.js';
 
 describe('Admin Settings Controller', () => {
   it('should get settings', () => {
     const req = {};
     const res = { json: jest.fn() };
-    adminController.getSettings(req, res);
+    getSettings(req, res);
     expect(res.json).toHaveBeenCalledWith({ settings: {} });
   });
 
   it('should update settings', () => {
     const req = {};
     const res = { json: jest.fn() };
-    adminController.updateSettings(req, res);
+    updateSettings(req, res);
     expect(res.json).toHaveBeenCalledWith({ message: 'update settings placeholder' });
   });
 });


### PR DESCRIPTION
## Summary
- allow optional .js extensions and add targeted overrides for scripts and tests
- include @jest/globals and loosen rules for test utilities
- refactor seeding script to avoid awaiting in loops and update sample test imports

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895ce50135c832eb721fcd147574d7e