### PR TITLE
test: wrap admin page tests with act

### DIFF
--- a/client/src/admin/pages/__tests__/Dashboard.test.jsx
+++ b/client/src/admin/pages/__tests__/Dashboard.test.jsx
@@ -1,13 +1,19 @@
-import { render } from '@testing-library/react';
+import { render, act, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import Dashboard from '../Dashboard.jsx';
 
+jest.spyOn(console, 'warn').mockImplementation(() => {});
+
 describe('Dashboard Page', () => {
-  it('renders without crashing', () => {
-    render(
-      <MemoryRouter>
-        <Dashboard />
-      </MemoryRouter>
-    );
+  it('renders without crashing', async () => {
+    let result;
+    await act(async () => {
+      result = render(
+        <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+          <Dashboard />
+        </MemoryRouter>
+      );
+    });
+    await waitFor(() => expect(result.container).toBeInTheDocument());
   });
 });

--- a/client/src/admin/pages/__tests__/Settings.test.jsx
+++ b/client/src/admin/pages/__tests__/Settings.test.jsx
@@ -1,13 +1,19 @@
-import { render } from '@testing-library/react';
+import { render, act, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import Settings from '../Settings.jsx';
 
+jest.spyOn(console, 'warn').mockImplementation(() => {});
+
 describe('Settings Page', () => {
-  it('renders without crashing', () => {
-    render(
-      <MemoryRouter>
-        <Settings />
-      </MemoryRouter>
-    );
+  it('renders without crashing', async () => {
+    let result;
+    await act(async () => {
+      result = render(
+        <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+          <Settings />
+        </MemoryRouter>
+      );
+    });
+    await waitFor(() => expect(result.container).toBeInTheDocument());
   });
 });

--- a/client/src/admin/pages/__tests__/StoreDetails.test.jsx
+++ b/client/src/admin/pages/__tests__/StoreDetails.test.jsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { render, act, waitFor } from '@testing-library/react';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import StoreDetails from '../StoreDetails.jsx';
 import { getStoreMetrics } from '../../../services/api.js';
@@ -17,15 +17,23 @@ jest.mock('recharts', () => ({
   ResponsiveContainer: ({ children }) => <div>{children}</div>,
 }));
 
+jest.spyOn(console, 'warn').mockImplementation(() => {});
+
 describe('StoreDetails Page', () => {
-  it('renders without crashing', () => {
+  it('renders without crashing', async () => {
     getStoreMetrics.mockResolvedValue({ data: {} });
-    render(
-      <MemoryRouter initialEntries={['/admin/stores/1']}>
-        <Routes>
-          <Route path="/admin/stores/:storeId" element={<StoreDetails />} />
-        </Routes>
-      </MemoryRouter>
-    );
+    await act(async () => {
+      render(
+        <MemoryRouter
+          initialEntries={['/admin/stores/1']}
+          future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+        >
+          <Routes>
+            <Route path="/admin/stores/:storeId" element={<StoreDetails />} />
+          </Routes>
+        </MemoryRouter>
+      );
+    });
+    await waitFor(() => expect(getStoreMetrics).toHaveBeenCalled());
   });
 });

--- a/client/src/admin/pages/__tests__/StoresList.test.jsx
+++ b/client/src/admin/pages/__tests__/StoresList.test.jsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { render, act, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import StoresList from '../StoresList.jsx';
 import { getStores } from '../../../services/api.js';
@@ -7,13 +7,18 @@ jest.mock('../../../services/api.js', () => ({
   getStores: jest.fn(),
 }));
 
+jest.spyOn(console, 'warn').mockImplementation(() => {});
+
 describe('StoresList Page', () => {
-  it('renders without crashing', () => {
+  it('renders without crashing', async () => {
     getStores.mockResolvedValue({ data: { stores: [], total: 0 } });
-    render(
-      <MemoryRouter>
-        <StoresList />
-      </MemoryRouter>
-    );
+    await act(async () => {
+      render(
+        <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+          <StoresList />
+        </MemoryRouter>
+      );
+    });
+    await waitFor(() => expect(getStores).toHaveBeenCalled());
   });
 });

--- a/client/src/admin/pages/__tests__/ThemeAdmin.test.jsx
+++ b/client/src/admin/pages/__tests__/ThemeAdmin.test.jsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { render, act, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import ThemeAdmin from '../ThemeAdmin.jsx';
 import { getThemes } from '../../../services/api.js';
@@ -7,13 +7,18 @@ jest.mock('../../../services/api.js', () => ({
   getThemes: jest.fn(),
 }));
 
+jest.spyOn(console, 'warn').mockImplementation(() => {});
+
 describe('ThemeAdmin Page', () => {
-  it('renders without crashing', () => {
+  it('renders without crashing', async () => {
     getThemes.mockResolvedValue({ data: { themes: [], total: 0 } });
-    render(
-      <MemoryRouter>
-        <ThemeAdmin />
-      </MemoryRouter>
-    );
+    await act(async () => {
+      render(
+        <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+          <ThemeAdmin />
+        </MemoryRouter>
+      );
+    });
+    await waitFor(() => expect(getThemes).toHaveBeenCalled());
   });
 });

--- a/client/src/admin/pages/__tests__/Users.test.jsx
+++ b/client/src/admin/pages/__tests__/Users.test.jsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { render, act, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import Users from '../Users.jsx';
 import { getUsers } from '../../../services/api.js';
@@ -7,13 +7,18 @@ jest.mock('../../../services/api.js', () => ({
   getUsers: jest.fn(),
 }));
 
+jest.spyOn(console, 'warn').mockImplementation(() => {});
+
 describe('Users Page', () => {
-  it('renders without crashing', () => {
+  it('renders without crashing', async () => {
     getUsers.mockResolvedValue({ data: { users: [], total: 0 } });
-    render(
-      <MemoryRouter>
-        <Users />
-      </MemoryRouter>
-    );
+    await act(async () => {
+      render(
+        <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+          <Users />
+        </MemoryRouter>
+      );
+    });
+    await waitFor(() => expect(getUsers).toHaveBeenCalled());
   });
 });


### PR DESCRIPTION
## Summary
- wrap admin page tests in `act` and use `waitFor`
- mock `console.warn` and enable React Router v7 future flags

## Testing
- `npm test -- --coverage=false`


------
https://chatgpt.com/codex/tasks/task_e_6895ea005b78832e866c5cd03f7538d2