### PR TITLE
test: stabilize admin e2e

### DIFF
--- a/client/cypress.config.js
+++ b/client/cypress.config.js
@@ -1,9 +1,8 @@
-const baseUrl = process.env.RENDER_URL || 'https://moohaarapp.onrender.com';
-
 module.exports = {
   e2e: {
-    baseUrl,
+    baseUrl: 'http://localhost:3000',
     specPattern: 'cypress/e2e/**/*.cy.js',
     supportFile: 'cypress/support/index.js',
+    defaultCommandTimeout: 10000,
   },
 };

--- a/client/cypress/e2e/admin.cy.js
+++ b/client/cypress/e2e/admin.cy.js
@@ -1,7 +1,15 @@
+before(() => {
+  if (!Cypress.env('CI')) {
+    cy.exec('npm run start -- --silent');
+    cy.wait(5000);
+  }
+});
+
 describe('Admin E2E', () => {
   it('logs in as an admin', () => {
     cy.intercept('POST', '/api/auth/login', { statusCode: 200, body: { token: 'fake' } }).as('login');
-    cy.visit('/login');
+    cy.visit('/login', { failOnStatusCode: false });
+    cy.get('input[name="email"]').should('be.visible');
     cy.get('input[name="email"]').type('admin@example.com');
     cy.get('input[name="password"]').type('password123');
     cy.contains('Sign in').click();
@@ -10,8 +18,8 @@ describe('Admin E2E', () => {
   });
 
   it('navigates to each admin section', () => {
-    cy.visit('/admin');
-    cy.contains('Dashboard');
+    cy.visit('/admin', { failOnStatusCode: false });
+    cy.contains('Dashboard').should('be.visible');
     cy.contains('Stores').click();
     cy.url().should('include', '/admin/stores');
     cy.contains('Users').click();
@@ -23,7 +31,8 @@ describe('Admin E2E', () => {
   });
 
   it('performs a simple CRUD operation', () => {
-    cy.visit('/admin/users');
+    cy.visit('/admin/users', { failOnStatusCode: false });
+    cy.contains('Edit').should('be.visible');
     cy.contains('Edit').click();
     cy.contains('Edit Roles').should('be.visible');
     cy.contains('Close').click();


### PR DESCRIPTION
## Summary
- use localhost as Cypress baseUrl and allow extra time for slow server startup
- start server in admin E2E and ignore transient 503s during navigation

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689618883cac832eb2013fe9076152a1