### PR TITLE
Fix cypress server verification error

### DIFF
--- a/client/cypress.config.js
+++ b/client/cypress.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   e2e: {
-    baseUrl: 'http://localhost:3000',
+    baseUrl: process.env.RENDER_URL || process.env.CYPRESS_BASE_URL || process.env.BASE_URL || 'http://localhost:4173',
     specPattern: 'cypress/e2e/**/*.cy.js',
     supportFile: 'cypress/support/index.js',
     defaultCommandTimeout: 10000,


### PR DESCRIPTION
Update Cypress `baseUrl` to dynamically use `RENDER_URL` in CI, fixing the 'server not running' error.

---
<a href="https://cursor.com/background-agent?bcId=bc-b5faf7a0-b883-49ec-8dc9-68b3cdb07bc0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b5faf7a0-b883-49ec-8dc9-68b3cdb07bc0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

