### PR TITLE
Fix failing unit tests and coverage issues

### DIFF
--- a/moohaar-backend/jest.config.js
+++ b/moohaar-backend/jest.config.js
@@ -1,5 +1,13 @@
 export default {
   testEnvironment: 'node',
+  testMatch: [
+    '**/__tests__/**/*.test.js',
+    '**/?(*.)+(spec|test).js'
+  ],
+  testPathIgnorePatterns: [
+    '/node_modules/',
+    '/mocks/'
+  ],
   coveragePathIgnorePatterns: [
     '/node_modules/',
     'src/server.js',
@@ -9,6 +17,7 @@ export default {
     '/src/utils/',
     'src/controllers/adminAuth.controller.js',
     'src/middleware/adminAuth.js',
+    '/mocks/'
   ],
   collectCoverageFrom: ['src/**/*.{js,jsx}'],
   coverageThreshold: {

--- a/moohaar-backend/src/routes/__tests__/mocks/order.mock.js
+++ b/moohaar-backend/src/routes/__tests__/mocks/order.mock.js
@@ -38,3 +38,5 @@ class MockOrder {
     this.orders = orders;
   }
 }
+
+export default MockOrder;


### PR DESCRIPTION
Fix Jest test failures by adding a default export to `order.mock.js` and configuring Jest to correctly identify and ignore mock files.

The previous Jest configuration was incorrectly treating mock files as test suites, leading to "no tests found" errors and an import error for `order.mock.js`. This PR resolves these issues by explicitly defining test file patterns and ignoring mock directories in `jest.config.js`, and by adding the necessary default export.

---
<a href="https://cursor.com/background-agent?bcId=bc-db88a1ae-0b5d-4329-b205-a655e702fcb5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-db88a1ae-0b5d-4329-b205-a655e702fcb5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

